### PR TITLE
refactor: simplify the websoc combine process

### DIFF
--- a/api/routes/websoc/websoc.service.ts
+++ b/api/routes/websoc/websoc.service.ts
@@ -58,7 +58,7 @@ const isolateSection = (data: EnhancedSection): EnhancedSection => {
  * @param responses The responses to combine.
  */
 export const combineResponses = (
-  responses: WebsocAPIResponse[]
+  ...responses: WebsocAPIResponse[]
 ): WebsocAPIResponse => {
   /**
    * sections are enhanced with context of parent structures and unique meetings

--- a/api/routes/websoc/websoc.service.ts
+++ b/api/routes/websoc/websoc.service.ts
@@ -1,0 +1,125 @@
+import hash from "object-hash";
+import type {
+  WebsocAPIResponse,
+  WebsocCourse,
+  WebsocDepartment,
+  WebsocSchool,
+  WebsocSection,
+  WebsocSectionMeeting,
+} from "peterportal-api-next-types";
+
+/**
+ * preserves context for each section
+ */
+interface EnhancedSection {
+  school: WebsocSchool;
+  department: WebsocDepartment;
+  course: WebsocCourse;
+  section: WebsocSection;
+}
+
+/**
+ * Combines all given response objects into a single response object,
+ * eliminating duplicates and merging substructures.
+ * @param responses The responses to combine.
+ */
+export const combineResponses = (
+  responses: WebsocAPIResponse[]
+): WebsocAPIResponse => {
+  /**
+   * all sections are enhanced with contextual info from parent structures
+   */
+  const allSections: EnhancedSection[] = responses
+    .map((response) =>
+      response.schools
+        .map((school) =>
+          school.departments
+            .map((department) =>
+              department.courses
+                .map((course) =>
+                  course.sections
+                    .map((section) => ({
+                      school,
+                      department,
+                      course,
+                      section,
+                    }))
+                    .flat()
+                )
+                .flat()
+            )
+            .flat()
+        )
+        .flat()
+    )
+    .flat();
+
+  /**
+   * for each section:
+   * if one of its parent structures hasn't been declared,
+   * append that structure appropriately
+   */
+  const schools = allSections.reduce((acc, section) => {
+    const foundSchool = acc.find(
+      (s) => s.schoolName === section.school.schoolName
+    );
+    if (!foundSchool) {
+      acc.push(section.school);
+      return acc;
+    }
+
+    const foundDept = foundSchool.departments.find(
+      (d) => d.deptCode === section.department.deptCode
+    );
+    if (!foundDept) {
+      foundSchool.departments.push(section.department);
+      return acc;
+    }
+
+    const foundCourse = foundDept.courses.find(
+      (c) =>
+        c.courseNumber === section.course.courseNumber &&
+        c.courseTitle === section.course.courseTitle
+    );
+    if (!foundCourse) {
+      foundDept.courses.push(section.course);
+      return acc;
+    }
+
+    const foundSection = foundCourse.sections.find(
+      (s) => s.sectionCode === section.section.sectionCode
+    );
+    if (!foundSection) {
+      foundCourse.sections.push(section.section);
+      return acc;
+    }
+
+    return acc;
+  }, [] as WebsocSchool[]);
+
+  /**
+   * all sections have been located properly in the combined structure,
+   * calculate the meetings for each section
+   * TODO: maybe this can be simplified too?
+   */
+  schools.forEach((s) => {
+    s.departments.forEach((d) => {
+      d.courses.forEach((c) => {
+        c.sections.forEach((e) => {
+          const meetingsHashSet: Record<string, WebsocSectionMeeting> = {};
+          for (const meeting of e.meetings) {
+            const meetingHash = hash([meeting.days, meeting.time]);
+            if (meetingHash in meetingsHashSet) {
+              meetingsHashSet[meetingHash].bldg.push(meeting.bldg[0]);
+            } else {
+              meetingsHashSet[meetingHash] = { ...meeting };
+            }
+            e.meetings = Object.values(meetingsHashSet);
+          }
+        });
+      });
+    });
+  });
+
+  return { schools };
+};

--- a/api/routes/websoc/websoc.service.ts
+++ b/api/routes/websoc/websoc.service.ts
@@ -38,7 +38,7 @@ export const combineResponses = (
                 .map((course) =>
                   course.sections
                     .map((section) => {
-                      const meetings = section.meetings.reduce(
+                      const dedupedMeetings = section.meetings.reduce(
                         (acc, meeting) => {
                           if (
                             !acc.find(
@@ -53,11 +53,29 @@ export const combineResponses = (
                         },
                         [] as WebsocSectionMeeting[]
                       );
+
+                      const dedupedSection = {
+                        ...section,
+                        meetings: dedupedMeetings,
+                      };
+                      const dedupedCourse = {
+                        ...course,
+                        sections: [dedupedSection],
+                      };
+                      const dedupedDepartment = {
+                        ...department,
+                        courses: [dedupedCourse],
+                      };
+                      const dedupedSchool = {
+                        ...school,
+                        departments: [dedupedDepartment],
+                      };
+
                       return {
-                        school,
-                        department,
-                        course,
-                        section: { ...section, meetings },
+                        school: dedupedSchool,
+                        department: dedupedDepartment,
+                        course: dedupedCourse,
+                        section: dedupedSection,
                       };
                     })
                     .flat()


### PR DESCRIPTION
# Summary
Attempt to reduce the complexity of the combining function.
Proposal / demo of how it could look instead.
Needs testing and verification because I've never actually seen or interacted with the `WebsocResponse[]`

# Strategy
1. Use `map` and `flat` to generate a flattened array of enhanced sections: sections that have contextual metadata about the school, department, and course they're in
2. Use `reduce` to create an array of schools by iterating through enhanced sections and handling each appropriately.
- Attempt to find some "part" of the section in the accumulated array of schools
- If it doesn't exist, then add that "part" of the section to the corresponding property of the accumulated schools
- Otherwise, index into the found "part" and repeat


# Notes
- Doesn't replace the current implementation yet because idk how to test it
- This solution intends to "abuse" object references to `push` to the correct arrays, but I'm not sure how this actually plays out in reality -- i.e. where we should make deep copies or keep original references

# Why
- Easier to read and reason about for my smol brain
- No more dependence on the external `object-hash` library
- Better utilizes TypeScript null checking and guarding to prevent superfluous optional chaining and re-indexing of previously processed arrays