### PR TITLE
feat: update WebSoc endpoint

### DIFF
--- a/api/routes/graphql/schema/websoc.graphql
+++ b/api/routes/graphql/schema/websoc.graphql
@@ -105,6 +105,8 @@ extend type Query {
     year: String!
     quarter: Quarter!
     cache: Boolean
+    cacheOnly: Boolean
+    includeCoCourses: Boolean
     ge: GE
     department: String
     sectionCodes: String

--- a/api/routes/websoc/index.ts
+++ b/api/routes/websoc/index.ts
@@ -77,7 +77,7 @@ export const rawHandler: RawHandler = async (request) => {
                     ? courses[department].push(courseNumber)
                     : (courses[department] = [courseNumber]);
                 });
-                const promises = Object.entries(courses).map(
+                const transactions = Object.entries(courses).map(
                   ([department, courseNumbers]) =>
                     prisma.websocSection.findMany({
                       where: {
@@ -88,7 +88,7 @@ export const rawHandler: RawHandler = async (request) => {
                       distinct: ["year", "quarter", "sectionCode"],
                     })
                 );
-                const responses = (await Promise.all(promises))
+                const responses = (await prisma.$transaction(transactions))
                   .flat()
                   .map((x) => x.data)
                   .filter(notNull) as WebsocAPIResponse[];

--- a/api/routes/websoc/index.ts
+++ b/api/routes/websoc/index.ts
@@ -32,43 +32,85 @@ export const rawHandler: RawHandler = async (request) => {
       try {
         const parsedQuery = QuerySchema.parse(query);
 
-        /**
-         * Check whether an entry with the specified term exists in the sections table.
-         * If not, then we're probably not scraping that term, so just proxy WebSoc.
-         */
-        const termExists = await prisma.websocSection.findFirst({
-          where: { year: parsedQuery.year, quarter: parsedQuery.quarter },
-        });
-
-        if (parsedQuery.cache && termExists) {
-          const websocSections = await prisma.websocSection.findMany({
-            where: constructPrismaQuery(parsedQuery),
-            select: { data: true },
-            distinct: ["year", "quarter", "sectionCode"],
+        if (parsedQuery.cache) {
+          /**
+           * Check whether an entry with the specified term exists in the sections table.
+           * If not, then we're probably not scraping that term, so just proxy WebSoc.
+           */
+          const termExists = await prisma.websocSection.findFirst({
+            where: { year: parsedQuery.year, quarter: parsedQuery.quarter },
           });
+          if (termExists || parsedQuery.cacheOnly) {
+            const websocSections = await prisma.websocSection.findMany({
+              where: constructPrismaQuery(parsedQuery),
+              select: { department: true, courseNumber: true, data: true },
+              distinct: ["year", "quarter", "sectionCode"],
+            });
 
-          /**
-           * WebSoc throws an error if a query returns more than 900 sections,
-           * so we probably want to maintain this invariant as well.
-           * (Also to prevent abuse of the endpoint.)
-           */
-          if (websocSections.length > 900) {
-            return createErrorResult(
-              400,
-              "More than 900 sections matched your query. Please refine your search.",
-              requestId
-            );
-          }
+            /**
+             * WebSoc throws an error if a query returns more than 900 sections,
+             * so we want to maintain this invariant as well, but only if
+             * cacheOnly is set to false.
+             */
+            if (websocSections.length > 900 && !parsedQuery.cacheOnly) {
+              return createErrorResult(
+                400,
+                "More than 900 sections matched your query. Please refine your search.",
+                requestId
+              );
+            }
 
-          /**
-           * Return found sections if using cache and they exist in database.
-           */
-          if (websocSections.length) {
-            const websocApiResponses = websocSections
-              .map((x) => x.data)
-              .filter(notNull) as WebsocAPIResponse[];
-            const combinedResponses = combineResponses(...websocApiResponses);
-            return createOKResult(sortResponse(combinedResponses), requestId);
+            /**
+             * Return found sections if we're using the cache and if they exist
+             * in the database.
+             */
+            if (websocSections.length) {
+              /**
+               * If the includeCoCourses flag is set, get a mapping of all
+               * departments to the included course numbers, and return all
+               * sections that match from the database.
+               */
+              if (parsedQuery.includeCoCourses) {
+                const courses: Record<string, string[]> = {};
+                websocSections.forEach(({ department, courseNumber }) => {
+                  courses[department]
+                    ? courses[department].push(courseNumber)
+                    : (courses[department] = [courseNumber]);
+                });
+                const promises = Object.entries(courses).map(
+                  ([department, courseNumbers]) =>
+                    prisma.websocSection.findMany({
+                      where: {
+                        department,
+                        courseNumber: { in: courseNumbers },
+                      },
+                      select: { data: true },
+                      distinct: ["year", "quarter", "sectionCode"],
+                    })
+                );
+                const responses = (await Promise.all(promises))
+                  .flat()
+                  .map((x) => x.data)
+                  .filter(notNull) as WebsocAPIResponse[];
+                const combinedResponses = combineResponses(...responses);
+                return createOKResult(
+                  sortResponse(combinedResponses),
+                  requestId
+                );
+              }
+              const websocApiResponses = websocSections
+                .map((x) => x.data)
+                .filter(notNull) as WebsocAPIResponse[];
+              const combinedResponses = combineResponses(...websocApiResponses);
+              return createOKResult(sortResponse(combinedResponses), requestId);
+            }
+            /**
+             * If this code is reached and the cacheOnly flag is set, return
+             * an empty WebsocAPIResponse object. Otherwise, fall back to
+             * querying WebSoc.
+             */
+            if (parsedQuery.cacheOnly)
+              return createOKResult({ schools: [] }, requestId);
           }
         }
 

--- a/api/routes/websoc/lib.ts
+++ b/api/routes/websoc/lib.ts
@@ -311,25 +311,19 @@ export function constructPrismaQuery(
   }
 
   if (parsedQuery.building) {
-    if (parsedQuery.room) {
-      AND.push({
-        meetings: {
-          every: {
-            buildings: {
-              some: { bldg: `${parsedQuery.building} ${parsedQuery.room}` },
+    AND.push({
+      meetings: {
+        every: {
+          buildings: {
+            some: {
+              bldg: parsedQuery.room
+                ? `${parsedQuery.building} ${parsedQuery.room}`
+                : { contains: parsedQuery.building },
             },
           },
         },
-      });
-    } else {
-      AND.push({
-        meetings: {
-          every: {
-            buildings: { some: { bldg: { contains: parsedQuery.building } } },
-          },
-        },
-      });
-    }
+      },
+    });
   }
 
   if (parsedQuery.sectionCodes) {

--- a/api/routes/websoc/lib.ts
+++ b/api/routes/websoc/lib.ts
@@ -310,6 +310,28 @@ export function constructPrismaQuery(
       AND.push({ cancelled: true });
   }
 
+  if (parsedQuery.building) {
+    if (parsedQuery.room) {
+      AND.push({
+        meetings: {
+          every: {
+            buildings: {
+              some: { bldg: `${parsedQuery.building} ${parsedQuery.room}` },
+            },
+          },
+        },
+      });
+    } else {
+      AND.push({
+        meetings: {
+          every: {
+            buildings: { some: { bldg: { contains: parsedQuery.building } } },
+          },
+        },
+      });
+    }
+  }
+
   if (parsedQuery.sectionCodes) {
     OR.push(
       ...parsedQuery.sectionCodes.map((code) => ({

--- a/api/routes/websoc/schema.ts
+++ b/api/routes/websoc/schema.ts
@@ -119,8 +119,8 @@ export const QuerySchema = z
   .refine((x) => x.cache || !x.cacheOnly, {
     message: "cacheOnly cannot be true if cache is false",
   })
-  .refine((x) => x.cache || !x.cacheOnly, {
-    message: "includeCoCourses cannot be true if cache is false",
+  .refine((x) => x.cacheOnly || !x.includeCoCourses, {
+    message: "includeCoCourses cannot be true if cacheOnly is false",
   })
   .refine(
     (x) =>

--- a/docs/docs/rest-api/reference/grades.md
+++ b/docs/docs/rest-api/reference/grades.md
@@ -8,9 +8,9 @@ import TabItem from "@theme/TabItem";
 
 # Grades
 
-PeterPortal API maintains a database of past grades dating back to 2014 Summer Session 1. This database is updated from the [Public Records Office](https://pro.uci.edu/) as soon as they are available.
+PeterPortal API maintains a database of past grades dating back to 2014 Summer Session 1. This database is updated from the [Public Records Office](https://pro.uci.edu/) as soon as they are available. This endpoint allows users to query that database with any desired filters.
 
-Please note that due to the size of the data, not providing any filters for the grades statistics endpoints will most likely result in an error. If you must fetch all data from the database at once, please consider doing so by year.
+Please note that due to the size of the database, not providing any filters for the grades statistics endpoints will most likely result in an error. If you must fetch all data from the database at once, please consider doing so by year.
 
 ## Query parameters for all endpoints
 

--- a/docs/docs/rest-api/reference/websoc.md
+++ b/docs/docs/rest-api/reference/websoc.md
@@ -6,12 +6,11 @@ pagination_next: null
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# WebSOC
+# WebSoC
 
-<span style={{ color: "var(--ifm-color-primary-lightest)" }}>
+The WebSoC (Web Schedule of Classes) endpoint allows programmatic access to the UCI Schedule of Classes.
 
-<h2>Use the REST API to get information from WebSOC.</h2>
-</span>
+PeterPortal API maintains a cache of all WebSoc data, which is updated every hour. By default, the endpoint will return data from the cache if it can, falling back to WebSoc on a cache miss. This improves the overall response time, but may result in stale data.
 
 ## Query the Schedule of Classes
 
@@ -27,9 +26,17 @@ The quarter to query. Case-sensitive.
 
 #### `cache` boolean
 
-To improve response times, this endpoint will return data from our cache by default. The cache is updated approximately every five minutes.
+Whether to query the cache at all; defaults to `true`. If this is set to `false`, then the endpoint will query WebSoc directly instead. Note that disabling the cache for large queries may result in a timeout.
 
-If you would like to disable this behavior, pass `false` to this parameter. Note that disabling the cache for large queries may result in a timeout.
+#### `cacheOnly` boolean
+
+Whether to use the cache exclusively; defaults to `false`. If this is set to `true`, then none of the following parameters marked with **\*** are required, but cache misses will not result in a fallback query.
+
+#### `includeCoCourses` boolean
+
+When querying by GE categories, the default behavior of WebSoc is to return only the main section of the course that satisfies the desired GE category. Setting this flag to `true` also returns any co-courses (discussions, labs, etc.) associated with the main section, but requires `cacheOnly` to also be set to `true`.
+
+To preserve backwards compatibility with WebSoc, this defaults to `false`.
 
 #### `ge`**\*** ANY | GE-1A | GE-1B | GE-2 | GE-3 | GE-4 | GE-5A | GE-5B | GE-6 | GE-7 | GE-8
 
@@ -48,7 +55,7 @@ The five-digit section code(s).
 Any substring of the desired instructor's last name. To search an exact last
 name, append a comma to the parameter.
 
-At least one of the parameters marked with **\*** must be provided and must not be ANY.
+If `cacheOnly` is `false`, at least one of the parameters marked with **\*** must be provided and must not be ANY.
 
 #### `building` string
 
@@ -230,116 +237,6 @@ type WebsocAPIResponse = {
     }[];
   }[];
 };
-```
-
-</TabItem>
-</Tabs>
-
-## Get all available departments
-
-:::info
-
-This endpoint is not currently available; as such, the documentation outlined below is subject to change.
-
-:::
-
-### Query parameters
-
-None.
-
-### Code sample
-
-<Tabs>
-<TabItem value="bash" label="cURL">
-
-```bash
-curl "https://api-next.peterportal.org/v1/rest/websoc/departments"
-```
-
-</TabItem>
-</Tabs>
-
-### Response
-
-<Tabs>
-<TabItem value="json" label="Example payload">
-
-```json
-[
-  {
-    "deptLabel": "ALL: Include All Departments",
-    "deptValue": "ALL"
-  },
-  "...",
-  {
-    "deptLabel": "I&C SCI: Information and Computer Science",
-    "deptValue": "I&C SCI"
-  },
-  "..."
-]
-```
-
-</TabItem>
-<TabItem value="ts" label="Payload schema">
-
-```typescript
-// https://github.com/icssc/peterportal-api-next/blob/main/packages/peterportal-api-next-types/types/websoc.ts
-type DepartmentResponse = { deptLabel: string; deptValue: string }[];
-```
-
-</TabItem>
-</Tabs>
-
-## Get all available terms
-
-:::info
-
-This endpoint is not currently available; as such, the documentation outlined below is subject to change.
-
-:::
-
-### Query parameters
-
-None.
-
-### Code sample
-
-<Tabs>
-<TabItem value="bash" label="cURL">
-
-```bash
-curl "https://api-next.peterportal.org/v1/rest/websoc/terms"
-```
-
-</TabItem>
-</Tabs>
-
-### Response
-
-<Tabs>
-<TabItem value="json" label="Example payload">
-
-```json
-[
-  {
-    "shortName": "2023 Summer2",
-    "longName": "2023 Summer Session 2"
-  },
-  "...",
-  {
-    "shortName": "2023 Spring",
-    "longName": "2023 Spring Quarter"
-  },
-  "..."
-]
-```
-
-</TabItem>
-<TabItem value="ts" label="Payload schema">
-
-```typescript
-// https://github.com/icssc/peterportal-api-next/blob/main/packages/peterportal-api-next-types/types/websoc.ts
-type TermResponse = { shortName: string; longName: string }[];
 ```
 
 </TabItem>

--- a/docs/docs/rest-api/reference/websoc.md
+++ b/docs/docs/rest-api/reference/websoc.md
@@ -6,9 +6,9 @@ pagination_next: null
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-# WebSoC
+# WebSoc
 
-The WebSoC (Web Schedule of Classes) endpoint allows programmatic access to the UCI Schedule of Classes.
+The WebSoc (Web Schedule of Classes) endpoint allows programmatic access to the UCI Schedule of Classes.
 
 PeterPortal API maintains a cache of all WebSoc data, which is updated every hour. By default, the endpoint will return data from the cache if it can, falling back to WebSoc on a cache miss. This improves the overall response time, but may result in stale data.
 

--- a/libs/db/prisma/schema.prisma
+++ b/libs/db/prisma/schema.prisma
@@ -78,26 +78,31 @@ model WebsocSectionInstructor {
   name        String
 }
 
-model WebsocSectionMeeting {
-  id          Int           @id @default(autoincrement())
+model WebsocSectionMeetingBuilding {
+  id          Int                  @id @default(autoincrement())
   year        String
   quarter     Quarter
   sectionCode Int
   timestamp   DateTime
-  section     WebsocSection @relation(fields: [year, quarter, sectionCode, timestamp], references: [year, quarter, sectionCode, timestamp])
+  startTime   Int
+  endTime     Int
+  meeting     WebsocSectionMeeting @relation(fields: [year, quarter, sectionCode, timestamp, startTime, endTime], references: [year, quarter, sectionCode, timestamp, startTime, endTime])
+  bldg        String
+}
+
+model WebsocSectionMeeting {
+  id          Int                            @id @default(autoincrement())
+  year        String
+  quarter     Quarter
+  sectionCode Int
+  timestamp   DateTime
+  section     WebsocSection                  @relation(fields: [year, quarter, sectionCode, timestamp], references: [year, quarter, sectionCode, timestamp])
   days        Json
   startTime   Int
   endTime     Int
-  buildings   Json
-}
+  buildings   WebsocSectionMeetingBuilding[]
 
-model WebsocTerm {
-  year      String
-  quarter   Quarter
-  timestamp DateTime
-
-  @@id([year, quarter])
-  @@unique([year, quarter], name: "idx")
+  @@unique([year, quarter, sectionCode, timestamp, startTime, endTime], name: "idx")
 }
 
 model WebsocSection {

--- a/libs/db/prisma/schema.prisma
+++ b/libs/db/prisma/schema.prisma
@@ -84,9 +84,10 @@ model WebsocSectionMeetingBuilding {
   quarter     Quarter
   sectionCode Int
   timestamp   DateTime
+  daysString  String
   startTime   Int
   endTime     Int
-  meeting     WebsocSectionMeeting @relation(fields: [year, quarter, sectionCode, timestamp, startTime, endTime], references: [year, quarter, sectionCode, timestamp, startTime, endTime])
+  meeting     WebsocSectionMeeting @relation(fields: [year, quarter, sectionCode, timestamp, daysString, startTime, endTime], references: [year, quarter, sectionCode, timestamp, daysString, startTime, endTime])
   bldg        String
 }
 
@@ -98,11 +99,12 @@ model WebsocSectionMeeting {
   timestamp   DateTime
   section     WebsocSection                  @relation(fields: [year, quarter, sectionCode, timestamp], references: [year, quarter, sectionCode, timestamp])
   days        Json
+  daysString  String
   startTime   Int
   endTime     Int
   buildings   WebsocSectionMeetingBuilding[]
 
-  @@unique([year, quarter, sectionCode, timestamp, startTime, endTime], name: "idx")
+  @@unique([year, quarter, sectionCode, timestamp, daysString, startTime, endTime], name: "idx")
 }
 
 model WebsocSection {

--- a/libs/websoc-api-next/index.ts
+++ b/libs/websoc-api-next/index.ts
@@ -240,9 +240,9 @@ export const callWebSocAPI = async (
     school.departments.forEach((department) =>
       department.courses.forEach((course) =>
         course.sections.forEach((section) => {
-          section.meetings.forEach(
-            (meeting) => (meeting.bldg = [meeting.bldg] as unknown as string[])
-          );
+          section.meetings.forEach((meeting) => {
+            meeting.bldg = [meeting.bldg].flat();
+          });
           section.meetings = getUniqueMeetings(section.meetings);
         })
       )
@@ -253,12 +253,10 @@ export const callWebSocAPI = async (
 
 function getUniqueMeetings(meetings: WebsocSectionMeeting[]) {
   return meetings.reduce((acc, meeting) => {
-    let i;
-    if (
-      (i = acc.findIndex(
-        (m) => m.days === meeting.days && m.time === meeting.time
-      )) === -1
-    ) {
+    const i = acc.findIndex(
+      (m) => m.days === meeting.days && m.time === meeting.time
+    );
+    if (i === -1) {
       acc.push(meeting);
     } else {
       acc[i].bldg.push(...meeting.bldg);

--- a/libs/websoc-api-next/index.ts
+++ b/libs/websoc-api-next/index.ts
@@ -239,9 +239,12 @@ export const callWebSocAPI = async (
   json.schools.forEach((school) =>
     school.departments.forEach((department) =>
       department.courses.forEach((course) =>
-        course.sections.forEach(
-          (section) => (section.meetings = getUniqueMeetings(section.meetings))
-        )
+        course.sections.forEach((section) => {
+          section.meetings.forEach(
+            (meeting) => (meeting.bldg = [meeting.bldg] as unknown as string[])
+          );
+          section.meetings = getUniqueMeetings(section.meetings);
+        })
       )
     )
   );
@@ -250,8 +253,15 @@ export const callWebSocAPI = async (
 
 function getUniqueMeetings(meetings: WebsocSectionMeeting[]) {
   return meetings.reduce((acc, meeting) => {
-    if (!acc.find((m) => m.days === meeting.days && m.time === meeting.time)) {
+    let i;
+    if (
+      (i = acc.findIndex(
+        (m) => m.days === meeting.days && m.time === meeting.time
+      )) === -1
+    ) {
       acc.push(meeting);
+    } else {
+      acc[i].bldg.push(...meeting.bldg);
     }
     return acc;
   }, [] as WebsocSectionMeeting[]);

--- a/tools/websoc-scraper-v2/index.ts
+++ b/tools/websoc-scraper-v2/index.ts
@@ -69,6 +69,7 @@ type ProcessedMeeting = {
   sectionCode: number;
   timestamp: Date;
   days: string[];
+  daysString: string;
   startTime: number;
   endTime: number;
 };
@@ -81,6 +82,7 @@ type ProcessedMeetingBuilding = {
   quarter: Quarter;
   sectionCode: number;
   timestamp: Date;
+  daysString: string;
   startTime: number;
   endTime: number;
   bldg: string;
@@ -361,6 +363,7 @@ async function scrape(name: string, term: Term) {
                     sectionCode,
                     timestamp,
                     days: days.filter((x) => m.days.includes(x)),
+                    daysString: m.days,
                     ...parseStartAndEndTimes(m.time),
                   })),
                   buildings: section.meetings.flatMap((m) =>
@@ -369,6 +372,7 @@ async function scrape(name: string, term: Term) {
                       quarter,
                       sectionCode,
                       timestamp,
+                      daysString: m.days,
                       ...parseStartAndEndTimes(m.time),
                       bldg,
                     }))

--- a/tools/websoc-scraper-v2/index.ts
+++ b/tools/websoc-scraper-v2/index.ts
@@ -69,9 +69,21 @@ type ProcessedMeeting = {
   sectionCode: number;
   timestamp: Date;
   days: string[];
-  buildings: string[];
   startTime: number;
   endTime: number;
+};
+
+/**
+ * A meeting building object that can be inserted directly into Prisma.
+ */
+type ProcessedMeetingBuilding = {
+  year: string;
+  quarter: Quarter;
+  sectionCode: number;
+  timestamp: Date;
+  startTime: number;
+  endTime: number;
+  bldg: string;
 };
 
 /**
@@ -84,6 +96,7 @@ type ProcessedSection = {
   meta: {
     instructors: ProcessedInstructor[];
     meetings: ProcessedMeeting[];
+    buildings: ProcessedMeetingBuilding[];
   };
   /**
    * The section object that can be inserted directly into Prisma.
@@ -348,9 +361,18 @@ async function scrape(name: string, term: Term) {
                     sectionCode,
                     timestamp,
                     days: days.filter((x) => m.days.includes(x)),
-                    buildings: m.bldg,
                     ...parseStartAndEndTimes(m.time),
                   })),
+                  buildings: section.meetings.flatMap((m) =>
+                    m.bldg.map((bldg) => ({
+                      year,
+                      quarter,
+                      sectionCode,
+                      timestamp,
+                      ...parseStartAndEndTimes(m.time),
+                      bldg,
+                    }))
+                  ),
                 },
                 data: {
                   year,
@@ -402,50 +424,69 @@ async function scrape(name: string, term: Term) {
 
   logger.info(`Processed ${Object.keys(res).length} sections`);
 
-  const [sectionsCreated, instructorsCreated, meetingsCreated] =
-    await prisma.$transaction([
-      prisma.websocSection.createMany({
-        data: Object.values(res).map((d) => d.data),
-      }),
-      prisma.websocSectionInstructor.createMany({
-        data: Object.values(res).flatMap((d) => d.meta.instructors),
-      }),
-      prisma.websocSectionMeeting.createMany({
-        data: Object.values(res).flatMap((d) => d.meta.meetings),
-      }),
-    ]);
+  const [
+    sectionsCreated,
+    instructorsCreated,
+    meetingsCreated,
+    buildingsCreated,
+  ] = await prisma.$transaction([
+    prisma.websocSection.createMany({
+      data: Object.values(res).map((d) => d.data),
+    }),
+    prisma.websocSectionInstructor.createMany({
+      data: Object.values(res).flatMap((d) => d.meta.instructors),
+    }),
+    prisma.websocSectionMeeting.createMany({
+      data: Object.values(res).flatMap((d) => d.meta.meetings),
+    }),
+    prisma.websocSectionMeetingBuilding.createMany({
+      data: Object.values(res).flatMap((d) => d.meta.buildings),
+    }),
+  ]);
 
   logger.info(`Inserted ${sectionsCreated.count} sections`);
   logger.info(`Inserted ${instructorsCreated.count} instructors`);
   logger.info(`Inserted ${meetingsCreated.count} meetings`);
-  logger.info(`Inserted ${meetingsCreated.count} meetings`);
+  logger.info(`Inserted ${buildingsCreated.count} buildings`);
 
-  const [instructorsDeleted, meetingsDeleted, sectionsDeleted] =
-    await prisma.$transaction([
-      prisma.websocSectionInstructor.deleteMany({
-        where: {
-          year: term.year,
-          quarter: term.quarter,
-          timestamp: { lt: timestamp },
-        },
-      }),
-      prisma.websocSectionMeeting.deleteMany({
-        where: {
-          year: term.year,
-          quarter: term.quarter,
-          timestamp: { lt: timestamp },
-        },
-      }),
-      prisma.websocSection.deleteMany({
-        where: {
-          year: term.year,
-          quarter: term.quarter,
-          timestamp: { lt: timestamp },
-        },
-      }),
-    ]);
+  const [
+    instructorsDeleted,
+    buildingsDeleted,
+    meetingsDeleted,
+    sectionsDeleted,
+  ] = await prisma.$transaction([
+    prisma.websocSectionInstructor.deleteMany({
+      where: {
+        year: term.year,
+        quarter: term.quarter,
+        timestamp: { lt: timestamp },
+      },
+    }),
+    prisma.websocSectionMeetingBuilding.deleteMany({
+      where: {
+        year: term.year,
+        quarter: term.quarter,
+        timestamp: { lt: timestamp },
+      },
+    }),
+    prisma.websocSectionMeeting.deleteMany({
+      where: {
+        year: term.year,
+        quarter: term.quarter,
+        timestamp: { lt: timestamp },
+      },
+    }),
+    prisma.websocSection.deleteMany({
+      where: {
+        year: term.year,
+        quarter: term.quarter,
+        timestamp: { lt: timestamp },
+      },
+    }),
+  ]);
 
   logger.info(`Removed ${instructorsDeleted.count} instructors`);
+  logger.info(`Removed ${buildingsDeleted.count} buildings`);
   logger.info(`Removed ${meetingsDeleted.count} meetings`);
   logger.info(`Removed ${sectionsDeleted.count} sections`);
   logger.info("Sleeping for 5 minutes");

--- a/tools/websoc-scraper-v2/tsconfig.json
+++ b/tools/websoc-scraper-v2/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["dist/"]
+}


### PR DESCRIPTION
- Implement support for the `cacheOnly` flag (closes #24).
- Implement support for the `includeCoCourses` flag (closes #27).
- Implement filtering on buildings/rooms, and update the scraper to support this. Somehow the endpoint made it into prod without including this essential feature.