### PR TITLE
feat: arktype schemas complement peterportal types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7278,6 +7278,12 @@
       "version": "2.0.1",
       "license": "Python-2.0"
     },
+    "node_modules/arktype": {
+      "version": "1.0.14-alpha",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-1.0.14-alpha.tgz",
+      "integrity": "sha512-theD5K4QrYCWMtQ52Masj169IgtMJ8Argld/MBS4lotEwR3b+GzfBvsqVJ1OIKhJDTdES02FLQTjcfRe00//mA==",
+      "hasInstallScript": true
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "license": "MIT"
@@ -20636,8 +20642,11 @@
       }
     },
     "packages/peterportal-api-next-types": {
-      "version": "1.0.0-alpha.6",
-      "license": "MIT"
+      "version": "1.0.0-beta.0",
+      "license": "MIT",
+      "dependencies": {
+        "arktype": "^1.0.14-alpha"
+      }
     },
     "tools/cdk": {
       "name": "tools-cdk",
@@ -25606,6 +25615,11 @@
     },
     "argparse": {
       "version": "2.0.1"
+    },
+    "arktype": {
+      "version": "1.0.14-alpha",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-1.0.14-alpha.tgz",
+      "integrity": "sha512-theD5K4QrYCWMtQ52Masj169IgtMJ8Argld/MBS4lotEwR3b+GzfBvsqVJ1OIKhJDTdES02FLQTjcfRe00//mA=="
     },
     "array-flatten": {
       "version": "1.1.1"
@@ -30633,7 +30647,10 @@
       "version": "4.0.0"
     },
     "peterportal-api-next-types": {
-      "version": "file:packages/peterportal-api-next-types"
+      "version": "file:packages/peterportal-api-next-types",
+      "requires": {
+        "arktype": "*"
+      }
     },
     "picocolors": {
       "version": "1.0.0"

--- a/packages/peterportal-api-next-types/package.json
+++ b/packages/peterportal-api-next-types/package.json
@@ -4,5 +4,8 @@
   "license": "MIT",
   "type": "module",
   "main": "index.ts",
-  "types": "index.ts"
+  "types": "index.ts",
+  "dependencies": {
+    "arktype": "^1.0.14-alpha"
+  }
 }

--- a/packages/peterportal-api-next-types/schemas/calendar.ts
+++ b/packages/peterportal-api-next-types/schemas/calendar.ts
@@ -1,0 +1,16 @@
+import { type Infer, type } from "arktype";
+
+import { Quarter } from "../types/constants";
+
+export const WeekData = type({
+  week: "string",
+  quarter: "string" as Infer<`${string} ${Quarter}`>,
+  display: "string",
+});
+
+export const QuarterDates = type({
+  instructionStart: "Date",
+  instructionEnd: "Date",
+  finalsStart: "Date",
+  finalsEnd: "Date",
+});

--- a/packages/peterportal-api-next-types/schemas/courses.ts
+++ b/packages/peterportal-api-next-types/schemas/courses.ts
@@ -1,0 +1,44 @@
+import { type } from "arktype";
+
+import { courseLevels, geCategories } from "../types/constants";
+import enumerate from "./enumerate";
+
+export const PrerequisiteTree = type({
+  "AND?": "string[]",
+  "OR?": "string[]",
+});
+
+/**
+ * An object that represents a course.
+ * The type of the payload returned on a successful response from querying
+ * ``/v1/rest/courses/{courseId}``.
+ * @alpha
+ */
+export const Course = type({
+  id: "string",
+  department: "string",
+  courseNumber: "string",
+  courseNumeric: "number",
+  school: "string",
+  title: "string",
+  courseLevel: enumerate(courseLevels),
+  minUnits: "string",
+  maxUnits: "string",
+  description: "string",
+  departmentName: "string",
+  instructorHistory: "string[]",
+  prerequisiteTree: PrerequisiteTree,
+  prerequisiteList: "string[]",
+  prerequisiteText: "string",
+  prerequisiteFor: "string[]",
+  repeatability: "string",
+  gradingOption: "string",
+  concurrent: "string",
+  sameAs: "string",
+  restriction: "string",
+  overlap: "string",
+  corequisite: "string",
+  geList: enumerate(geCategories),
+  geText: "string",
+  terms: "string[]",
+});

--- a/packages/peterportal-api-next-types/schemas/enumerate.ts
+++ b/packages/peterportal-api-next-types/schemas/enumerate.ts
@@ -1,0 +1,5 @@
+function enumerate<T extends readonly string[]>(values: T) {
+  return values.map((v) => `"${v}"`).join("|") as `"${T[number]}"`;
+}
+
+export default enumerate;

--- a/packages/peterportal-api-next-types/schemas/grades.ts
+++ b/packages/peterportal-api-next-types/schemas/grades.ts
@@ -1,0 +1,47 @@
+import { arrayOf, type } from "arktype";
+
+import { quarters } from "../types/constants";
+import enumerate from "./enumerate";
+
+/**
+ * A section which has grades data associated with it.
+ */
+export const GradeSection = type({
+  year: "string",
+  quarter: enumerate(quarters),
+  department: "string",
+  courseNumber: "string",
+  courseNumeric: "number",
+  sectionCode: "string",
+  instructors: "string[]",
+});
+
+export const GradeDistribution = type({
+  gradeACount: "number",
+  gradeBCount: "number",
+  gradeCCount: "number",
+  gradeDCount: "number",
+  gradeFCount: "number",
+  gradePCount: "number",
+  gradeNPCount: "number",
+  gradeWCount: "number",
+  averageGPA: "number",
+});
+
+/**
+ * The type of the payload returned on a successful response from querying
+ * ``/v1/rest/grades/raw``.
+ * @alpha
+ */
+export const GradesRaw = arrayOf(type([GradeSection, "&", GradeDistribution]));
+
+/**
+ * An object that represents aggregate grades statistics for a given query.
+ * The type of the payload returned on a successful response from querying
+ * ``/v1/rest/grades/aggregate``.
+ * @alpha
+ */
+export const GradesAggregate = type({
+  sectionList: arrayOf(GradeSection),
+  gradeDistribution: GradeDistribution,
+});

--- a/packages/peterportal-api-next-types/schemas/index.ts
+++ b/packages/peterportal-api-next-types/schemas/index.ts
@@ -1,0 +1,5 @@
+export * from "./calendar";
+export * from "./courses";
+export * from "./grades";
+export * from "./instructor";
+export * from "./websoc";

--- a/packages/peterportal-api-next-types/schemas/instructor.ts
+++ b/packages/peterportal-api-next-types/schemas/instructor.ts
@@ -1,0 +1,20 @@
+import { arrayOf, type } from "arktype";
+
+/**
+ * An object representing an instructor.
+ * The type of the payload returned on a successful response from querying
+ * ``/v1/rest/instructors/{ucinetid}``.
+ * @alpha
+ */
+export const Instructor = type({
+  ucinetid: "string",
+  instructorName: "string",
+  shortenedName: "string",
+  title: "string",
+  department: "string",
+  schools: "string[]",
+  relatedDepartments: "string[]",
+  courseHistory: "string[]",
+});
+
+export const Instructors = arrayOf(Instructor);

--- a/packages/peterportal-api-next-types/schemas/websoc.ts
+++ b/packages/peterportal-api-next-types/schemas/websoc.ts
@@ -1,0 +1,81 @@
+import { type Infer, arrayOf, type } from "arktype";
+
+import { type Quarter, quarters } from "../types/constants";
+import enumerate from "./enumerate";
+
+export const WebsocSectionMeeting = type({
+  days: "string",
+  time: "string",
+  bldg: "string[]",
+});
+
+export const WebsocSectionEnrollment = type({
+  totalEnrolled: "string",
+  sectionEnrolled: "string",
+});
+
+export const WebsocSection = type({
+  sectionCode: "string",
+  sectionType: "string",
+  sectionNum: "string",
+  units: "string",
+  instructors: "string[]",
+  meetings: arrayOf(WebsocSectionMeeting),
+  finalExam: "string",
+  maxCapacity: "string",
+  numCurrentlyEnrolled: WebsocSectionEnrollment,
+  numOnWaitlist: "string",
+  numWaitlistCap: "string",
+  numRequested: "string",
+  numNewOnlyReserved: "string",
+  restrictions: "string",
+  status: enumerate(["OPEN", "Waitl", "FULL", "NewOnly"] as const),
+  sectionComment: "string",
+});
+
+export const WebsocCourse = type({
+  deptCode: "string",
+  courseNumber: "string",
+  courseTitle: "string",
+  courseComment: "string",
+  prerequisiteLink: "string",
+  sections: arrayOf(WebsocSection),
+});
+
+export const WebsocDepartment = type({
+  deptName: "string",
+  deptCode: "string",
+  deptComment: "string",
+  courses: arrayOf(WebsocCourse),
+  sectionCodeRangeComments: "string[]",
+  courseNumberRangeComments: "string[]",
+});
+
+export const WebsocSchool = type({
+  schoolName: "string",
+  schoolComment: "string",
+  departments: arrayOf(WebsocDepartment),
+});
+
+export const Term = type({
+  year: "string",
+  quarter: enumerate(quarters),
+});
+
+export const WebsocAPIResponse = {
+  schools: arrayOf(WebsocSchool),
+};
+
+export const Department = type({
+  deptLabel: "string",
+  deptValue: "string",
+});
+
+export const DepartmentResponse = arrayOf(Department);
+
+export const TermData = type({
+  shortName: "string" as Infer<`${string} ${Quarter}`>,
+  longName: "string",
+});
+
+export const TermResponse = arrayOf(TermData);


### PR DESCRIPTION
AA is using ArkType to define schemas. It would be nice if Peterportal had schemas that correlated with the type definitions :^)

Maybe it could be its own separate package or something. Ideally, the types should be defined directly from the schemas. But one thing I noticed is that the JSDoc doesn't carry over from schema to type def, which might be undesirable in a library :/