### PR TITLE
feat(ant-stack): implement route creation logic

### DIFF
--- a/apps/api/v1/rest/klein/src/index.ts
+++ b/apps/api/v1/rest/klein/src/index.ts
@@ -1,14 +1,19 @@
 import { createErrorResult, createOKResult, type InternalHandler, zeroUUID } from "ant-stack";
 
-export const GET: InternalHandler = async (event) => {
-  return createOKResult({ hello: "WORLD" }, zeroUUID);
-};
-export const POST: InternalHandler = async (event) => {
+const GET: InternalHandler = async (event) => {
   return createOKResult({}, zeroUUID);
 };
-export const PUT: InternalHandler = async (event) => {
+
+const POST: InternalHandler = async (event) => {
   return createOKResult({}, zeroUUID);
 };
-export const DELETE: InternalHandler = async (event) => {
+
+const PUT: InternalHandler = async (event) => {
   return createOKResult({}, zeroUUID);
 };
+
+const DELETE: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+
+export default { GET, POST, PUT, DELETE };

--- a/apps/api/v1/rest/test/src/index.ts
+++ b/apps/api/v1/rest/test/src/index.ts
@@ -1,14 +1,7 @@
 import { createErrorResult, createOKResult, type InternalHandler, zeroUUID } from "ant-stack";
 
-export const GET: InternalHandler = async (event) => {
+const GET: InternalHandler = async (event) => {
   return createOKResult({}, zeroUUID);
 };
-export const POST: InternalHandler = async (event) => {
-  return createOKResult({}, zeroUUID);
-};
-export const PUT: InternalHandler = async (event) => {
-  return createOKResult({}, zeroUUID);
-};
-export const DELETE: InternalHandler = async (event) => {
-  return createOKResult({}, zeroUUID);
-};
+
+export default { GET };

--- a/apps/api/v1/rest/test/src/index.ts
+++ b/apps/api/v1/rest/test/src/index.ts
@@ -4,4 +4,16 @@ const GET: InternalHandler = async (event) => {
   return createOKResult({}, zeroUUID);
 };
 
-export default { GET };
+const POST: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+
+const PUT: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+
+const DELETE: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+
+export default { GET, POST, PUT, DELETE };

--- a/env.ts
+++ b/env.ts
@@ -4,8 +4,6 @@ import { fileURLToPath } from "node:url";
 import { type } from "arktype";
 import { config } from "dotenv";
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 /**

--- a/packages/ant-stack/src/cli/commands/create.ts
+++ b/packages/ant-stack/src/cli/commands/create.ts
@@ -28,7 +28,9 @@ export async function interactiveCreate() {
     path = await consola.prompt("What is the path of the endpoint?", { type: "text" });
     if (!(path.match(/\/[0-9A-Za-z]+/) && !path.endsWith("/"))) {
       consola.error(
-        "Malformed path provided. A well-formed path must consist entirely of path parts (one slash followed by at least one alphanumeric character), and must not end with a slash (e.g. /v1/rest/test)."
+        chalk.red(
+          "Malformed path provided. A well-formed path must consist entirely of path parts (one slash followed by at least one alphanumeric character), and must not end with a slash (e.g. /v1/rest/test)."
+        )
       );
       continue;
     }
@@ -42,7 +44,7 @@ export async function interactiveCreate() {
       { type: "confirm" }
     );
     if (!create) {
-      consola.error("Aborting.");
+      consola.error(chalk.red("Aborting."));
       return;
     }
   }

--- a/packages/ant-stack/src/cli/commands/create.ts
+++ b/packages/ant-stack/src/cli/commands/create.ts
@@ -23,7 +23,7 @@ export async function interactiveCreate() {
   const config = await getConfig();
   consola.info(chalk("Creating a new endpoint."));
   let path = "",
-    success = false;
+  let success = false;
   while (!success) {
     path = await consola.prompt("What is the path of the endpoint?", { type: "text" });
     if (!(path.match(/\/[0-9A-Za-z]+/) && !path.endsWith("/"))) {

--- a/packages/ant-stack/src/cli/commands/create/index.template.ts
+++ b/packages/ant-stack/src/cli/commands/create/index.template.ts
@@ -1,0 +1,16 @@
+import { createErrorResult, createOKResult, type InternalHandler, zeroUUID } from "ant-stack";
+
+const GET: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+const POST: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+const PUT: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+const DELETE: InternalHandler = async (event) => {
+  return createOKResult({}, zeroUUID);
+};
+
+export default {};

--- a/packages/ant-stack/src/cli/commands/create/index.ts
+++ b/packages/ant-stack/src/cli/commands/create/index.ts
@@ -1,18 +1,13 @@
 import chalk from "chalk";
 import { consola } from "consola";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { format } from "prettier";
+import { fileURLToPath } from "url";
 
 import { getConfig } from "../../../config.js";
 
-const packageJson = (name: string) =>
-  `{"name": "api-${name
-    .slice(1)
-    .replace(
-      /\//g,
-      "-"
-    )}","version": "0.0.0","type": "module","scripts":{"dev": "ant dev","build": "ant build","start": "node dist"},"dependencies": {"ant-stack": "*"},"devDependencies":{"@types/node": "18","tsx": "*","typescript": "~5.0"}}`;
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const imports = `import { createErrorResult, createOKResult, type InternalHandler, zeroUUID } from "ant-stack"\n\n`;
 
@@ -54,7 +49,13 @@ export async function interactiveCreate() {
   });
   consola.info(`Creating an endpoint at ${path} that supports ${methods.join(", ")}`);
   mkdirSync(srcDir, { recursive: true });
-  writeFileSync(join(srcDir, "..", "package.json"), format(packageJson(path), { parser: "json" }));
+  writeFileSync(
+    join(srcDir, "..", "package.json"),
+    readFileSync(join(__dirname, "package.template.json"), { encoding: "utf-8" }).replace(
+      "$name",
+      `"api-${path.slice(1).replace(/\//g, "-")}"`
+    )
+  );
   writeFileSync(
     join(srcDir, "index.ts"),
     format([imports, ...methods.map((method) => handlers(method))].join(""), {

--- a/packages/ant-stack/src/cli/commands/create/index.ts
+++ b/packages/ant-stack/src/cli/commands/create/index.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 import { format } from "prettier";
 
-import { getConfig } from "../../config.js";
+import { getConfig } from "../../../config.js";
 
 const packageJson = (name: string) =>
   `{"name": "api-${name

--- a/packages/ant-stack/src/cli/commands/create/index.ts
+++ b/packages/ant-stack/src/cli/commands/create/index.ts
@@ -17,7 +17,7 @@ const handlers = (method: string) =>
 export async function interactiveCreate() {
   const config = await getConfig();
   consola.info(chalk("Creating a new endpoint."));
-  let path = "",
+  let path = "";
   let success = false;
   while (!success) {
     path = await consola.prompt("What is the path of the endpoint?", { type: "text" });

--- a/packages/ant-stack/src/cli/commands/create/package.template.json
+++ b/packages/ant-stack/src/cli/commands/create/package.template.json
@@ -1,0 +1,18 @@
+{
+  "name": "$name",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "ant dev",
+    "build": "ant build",
+    "start": "node dist"
+  },
+  "dependencies": {
+    "ant-stack": "*"
+  },
+  "devDependencies": {
+    "@types/node": "18",
+    "tsx": "*",
+    "typescript": "~5.0"
+  }
+}

--- a/packages/ant-stack/src/cli/index.ts
+++ b/packages/ant-stack/src/cli/index.ts
@@ -3,7 +3,7 @@ import { cli, command } from "cleye";
 import { consola } from "consola";
 
 import { buildInternalHandler } from "./commands/build.js";
-import { interactiveCreate } from "./commands/create.js";
+import { interactiveCreate } from "./commands/create";
 import { startDevServer } from "./commands/dev.js";
 
 async function start() {
@@ -47,5 +47,5 @@ async function start() {
 start();
 
 export * from "./commands/build.js";
-export * from "./commands/create.js";
+export * from "./commands/create";
 export * from "./commands/dev.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,22 @@ importers:
         specifier: ^4.9.4
         version: 4.9.5
 
+  apps/api/v1/rest/test:
+    dependencies:
+      ant-stack:
+        specifier: '*'
+        version: link:../../../../../packages/ant-stack
+    devDependencies:
+      '@types/node':
+        specifier: '18'
+        version: 18.14.0
+      tsx:
+        specifier: '*'
+        version: 3.12.7
+      typescript:
+        specifier: ~5.0
+        version: 5.0.4
+
   docs:
     dependencies:
       '@apollo/sandbox':
@@ -610,7 +626,7 @@ importers:
         version: link:../../packages/peterportal-api-next-types
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.22.1)(jest@29.4.1)(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.22.1)(jest@29.4.1)(typescript@5.0.4)
 
   libs/websoc-api-next:
     dependencies:
@@ -635,7 +651,7 @@ importers:
         version: link:../../packages/peterportal-api-next-types
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.22.1)(jest@29.4.1)(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.22.1)(jest@29.4.1)(typescript@5.0.4)
 
   packages/ant-stack:
     dependencies:
@@ -4175,13 +4191,13 @@ packages:
       '@types/node': 18.14.0
       chalk: 4.1.2
       cosmiconfig: 8.1.3
-      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.14.0)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@4.9.5)
+      cosmiconfig-typescript-loader: 4.3.0(@types/node@18.14.0)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.0.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@18.14.0)(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-node: 10.9.1(@types/node@18.14.0)(typescript@5.0.4)
+      typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -6084,7 +6100,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       chalk: 4.1.2
       jest-message-util: 29.5.0
       jest-util: 29.5.0
@@ -6105,14 +6121,14 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@20.2.5)(ts-node@10.9.1)
+      jest-config: 29.5.0(@types/node@18.14.0)(ts-node@10.9.1)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -6139,7 +6155,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       jest-mock: 29.5.0
     dev: true
 
@@ -6166,7 +6182,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@sinonjs/fake-timers': 10.2.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       jest-message-util: 29.5.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
@@ -6211,7 +6227,7 @@ packages:
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
       '@jridgewell/trace-mapping': 0.3.18
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -6298,7 +6314,7 @@ packages:
       '@jest/schemas': 29.4.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
@@ -6767,25 +6783,25 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
 
   /@types/bonjour@3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/connect-history-api-fallback@1.5.0:
     resolution: {integrity: sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==}
     dependencies:
       '@types/express-serve-static-core': 4.17.35
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/connect@3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
 
   /@types/cors@2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
@@ -6811,7 +6827,7 @@ packages:
   /@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
       '@types/send': 0.17.1
@@ -6827,7 +6843,7 @@ packages:
   /@types/graceful-fs@4.1.6:
     resolution: {integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: true
 
   /@types/hast@2.3.4:
@@ -6846,7 +6862,7 @@ packages:
   /@types/http-proxy@1.17.11:
     resolution: {integrity: sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/istanbul-lib-coverage@2.0.4:
@@ -6872,7 +6888,7 @@ packages:
   /@types/keyv@3.1.4:
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/long@4.0.2:
@@ -6898,7 +6914,7 @@ packages:
   /@types/node-fetch@2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       form-data: 3.0.1
     dev: false
 
@@ -6908,10 +6924,10 @@ packages:
 
   /@types/node@18.14.0:
     resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
-    dev: true
 
   /@types/node@20.2.5:
     resolution: {integrity: sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==}
+    dev: true
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -6968,7 +6984,7 @@ packages:
   /@types/responselike@1.0.0:
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/retry@0.12.0:
@@ -6978,7 +6994,7 @@ packages:
   /@types/sax@1.2.4:
     resolution: {integrity: sha512-pSAff4IAxJjfAXUG6tFkO7dsSbTmf8CtUpfhhZ5VhkRpC4628tJhh3+V6H1E+/Gs9piSzYKT5yzHO5M4GG9jkw==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/scheduler@0.16.3:
@@ -6992,7 +7008,7 @@ packages:
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
     dependencies:
       '@types/mime': 1.3.2
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
 
   /@types/serve-index@1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==}
@@ -7004,12 +7020,12 @@ packages:
     resolution: {integrity: sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
 
   /@types/sockjs@0.3.33:
     resolution: {integrity: sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/stack-utils@2.0.1:
@@ -7031,7 +7047,7 @@ packages:
   /@types/ws@8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
     dev: false
 
   /@types/yargs-parser@21.0.0:
@@ -8620,7 +8636,7 @@ packages:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  /cosmiconfig-typescript-loader@4.3.0(@types/node@18.14.0)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@4.9.5):
+  /cosmiconfig-typescript-loader@4.3.0(@types/node@18.14.0)(cosmiconfig@8.1.3)(ts-node@10.9.1)(typescript@5.0.4):
     resolution: {integrity: sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -8631,8 +8647,8 @@ packages:
     dependencies:
       '@types/node': 18.14.0
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@types/node@18.14.0)(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-node: 10.9.1(@types/node@18.14.0)(typescript@5.0.4)
+      typescript: 5.0.4
     dev: true
 
   /cosmiconfig@6.0.0:
@@ -9692,7 +9708,7 @@ packages:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       require-like: 0.1.2
     dev: false
 
@@ -11320,7 +11336,7 @@ packages:
       '@jest/expect': 29.5.0
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -11408,46 +11424,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config@29.5.0(@types/node@20.2.5)(ts-node@10.9.1):
-    resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.1
-      '@jest/test-sequencer': 29.5.0
-      '@jest/types': 29.5.0
-      '@types/node': 20.2.5
-      babel-jest: 29.5.0(@babel/core@7.22.1)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.5.0
-      jest-environment-node: 29.5.0
-      jest-get-type: 29.4.3
-      jest-regex-util: 29.4.3
-      jest-resolve: 29.5.0
-      jest-runner: 29.5.0
-      jest-util: 29.5.0
-      jest-validate: 29.5.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.5.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@18.14.0)(typescript@5.0.4)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /jest-diff@29.5.0:
     resolution: {integrity: sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -11483,7 +11459,7 @@ packages:
       '@jest/environment': 29.5.0
       '@jest/fake-timers': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
     dev: true
@@ -11499,7 +11475,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@types/graceful-fs': 4.1.6
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -11550,7 +11526,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       jest-util: 29.5.0
     dev: true
 
@@ -11605,7 +11581,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -11636,7 +11612,7 @@ packages:
       '@jest/test-result': 29.5.0
       '@jest/transform': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -11691,7 +11667,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -11715,7 +11691,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.5.0
       '@jest/types': 29.5.0
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -11727,7 +11703,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -11735,7 +11711,7 @@ packages:
     resolution: {integrity: sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 18.14.0
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -15058,7 +15034,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.0.5(@babel/core@7.22.1)(jest@29.4.1)(typescript@4.9.5):
+  /ts-jest@29.0.5(@babel/core@7.22.1)(jest@29.4.1)(typescript@5.0.4):
     resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -15088,39 +15064,8 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.1
-      typescript: 4.9.5
+      typescript: 5.0.4
       yargs-parser: 21.1.1
-    dev: true
-
-  /ts-node@10.9.1(@types/node@18.14.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.14.0
-      acorn: 8.8.2
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
     dev: true
 
   /ts-node@10.9.1(@types/node@18.14.0)(typescript@5.0.4):


### PR DESCRIPTION
Notable changes:
- Removed the background colors because the text with them were either illegible or made my eyes bleed. Generally I prefer minimal use of colors, even for a CLI tool, like how `pnpm` does it (as shown below).
![image](https://github.com/icssc/peterportal-api-next/assets/89349085/ea79fa92-f7ef-4451-9071-ad238480b2c1)
- Removed non-interactive route creation. We can add it back in later, but I feel that a tool like this should focus on DX, which means prioritizing interactivity.
- Removed `DATABASE_URL_SCRAPER` from the env. Normal members are not going to have access to it, and they don't need it for API route development anyways, which is what AntStack is for.

Caveats:
- I'm not sure how to start the development server properly; it errors at the root, and serves the given endpoint as the root when I run it from the endpoint's directory. Neither of these behaviors are desirable.