### PR TITLE
style: :art: renamed things for consistency

### DIFF
--- a/.github/actions/setup-node-and-pnpm/action.yml
+++ b/.github/actions/setup-node-and-pnpm/action.yml
@@ -1,14 +1,14 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-action.json
 ---
-name: Setup Node.JS and pnpm
+name: Setup Node.js and pnpm
 
-description: Sets up Node.JS and pnpm + pnpm cache. Does not install dependencies.
+description: Sets up Node.js and pnpm + pnpm cache. Does **not** install dependencies.
 
 runs:
   using: composite
 
   steps:
-    - name: Set up Node.js environment
+    - name: Setup Node.js environment
       uses: actions/setup-node@v3
       with:
         node-version: lts/hydrogen

--- a/.github/actions/wait-for-cloudformation-stack-idle/action.yml
+++ b/.github/actions/wait-for-cloudformation-stack-idle/action.yml
@@ -6,7 +6,7 @@ description: Wait until the specified CloudFormation stack is idle.
 
 inputs:
   stack_name:
-    description: The name of the stack to await.
+    description: The name of the CloudFormation stack to await.
     required: true
 
   aws_access_key_id:
@@ -19,7 +19,7 @@ inputs:
 
 outputs:
   stack-exists:
-    description: Whether the stack exists or not.
+    description: Whether the CloudFormation stack exists.
     value: ${{ steps.check-stack-exists.outcome == 'success' && !steps.wait-for-stack-delete.outcome == 'success'}}
 
 runs:
@@ -34,7 +34,7 @@ runs:
         aws-region: us-east-1
         role-duration-seconds: 2400
 
-    - name: Check if stack exists
+    - name: Check if CloudFormation stack exists
       id: check-stack-exists
       continue-on-error: true
       shell: bash
@@ -42,19 +42,19 @@ runs:
         STACK_STATUS=$(aws cloudformation describe-stacks --stack-name ${{inputs.stack_name }} --query "Stacks[0].StackStatus" --output text)
         echo "STACK_STATUS=$STACK_STATUS" >> $GITHUB_ENV
 
-    - name: Wait for stack to finish creating
+    - name: Wait for CloudFormation stack to finish creating
       if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'CREATE_IN_PROGRESS'
       continue-on-error: true
       shell: bash
       run: aws cloudformation wait stack-create-complete --stack-name ${{ inputs.stack_name }}
 
-    - name: Wait for stack to finish updating
+    - name: Wait for CloudFormation stack to finish updating
       if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'UPDATE_IN_PROGRESS'
       continue-on-error: true
       shell: bash
       run: aws cloudformation wait stack-update-complete --stack-name ${{ inputs.stack_name }}
 
-    - name: Wait for stack to finish deleting
+    - name: Wait for CloudFormation stack to finish deleting
       id: wait-for-stack-delete
       if: steps.check-stack-exists.outcome == 'success' && env.STACK_STATUS == 'DELETE_IN_PROGRESS'
       continue-on-error: true

--- a/.github/workflows/check-typescript.yml
+++ b/.github/workflows/check-typescript.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out codebase
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-prod-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: api-${{ github.ref }}
+  group: deploy-prod-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -38,14 +38,14 @@ jobs:
       url: https://api-next.peterportal.org
 
     steps:
-      - name: Check out codebase
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install dependencies
-        # NODE_ENV needs to be set to not production so pnpm will install devDependencies!!!
+        # Ensure NODE_ENV != production so pnpm will install devDependencies!!!
         run: NODE_ENV=development pnpm install --frozen-lockfile
 
       - name: Build AntStack
@@ -77,14 +77,14 @@ jobs:
       url: https://docs.api-next.peterportal.org
 
     steps:
-      - name: Check out codebase
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install dependencies
-        # NODE_ENV needs to be set to not production so pnpm will install devDependencies!!!
+        # Ensure NODE_ENV != production so pnpm will install devDependencies!!!
         run: NODE_ENV=development pnpm install --frozen-lockfile
 
       - name: Build documentation

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
 ---
-name: Deploy API and documentation to production environment
+name: Deploy CloudFormation stacks and production environment
 
 on:
   push:
@@ -29,7 +29,7 @@ env:
 
 jobs:
   deploy-api:
-    name: Deploy API to production environment
+    name: Deploy API CloudFormation stack and production environment
 
     runs-on: ubuntu-latest
 
@@ -64,11 +64,11 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
-      - name: Deploy API stack
+      - name: Deploy API CloudFormation stack
         run: pnpm run deploy --filter="ant-stack"
 
   deploy-documentation:
-    name: Deploy documentation to production environment
+    name: Deploy documentation CloudFormation stack and production environment
 
     runs-on: ubuntu-latest
 
@@ -87,7 +87,7 @@ jobs:
         # Ensure NODE_ENV != production so pnpm will install devDependencies!!!
         run: NODE_ENV=development pnpm install --frozen-lockfile
 
-      - name: Build documentation
+      - name: Build documentation CDK
         run: pnpm build --filter="docs-cdk"
 
       - name: Wait for documentation CloudFormation stack to idle
@@ -97,5 +97,5 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
-      - name: Deploy documentation stack
+      - name: Deploy documentation CloudFormation stack
         run: pnpm run deploy --filter="docs-cdk"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: deploy-staging-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
 ---
-name: Deploy staging environment for pull request
+name: Deploy CloudFormation stacks and staging environments for pull request
 
 on:
   pull_request:
@@ -32,7 +32,7 @@ env:
 
 jobs:
   deploy-api:
-    name: Deploy API staging environment for pull request
+    name: Deploy API CloudFormation stack and staging environment for pull request
 
     if: (!contains(github.event.pull_request.labels.*.name, 'no deploy'))
 
@@ -68,11 +68,11 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
-      - name: Deploy API stack
+      - name: Deploy API CloudFormation stack
         run: pnpm run deploy --filter="ant-stack"
 
   deploy-documentation:
-    name: Deploy documentation staging environment for pull request
+    name: Deploy documentation CloudFormation stack and staging environment for pull request
 
     if: (!contains(github.event.pull_request.labels.*.name, 'no deploy'))
 
@@ -92,7 +92,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build documentation
+      - name: Build documentation CDK
         run: pnpm build --filter="docs-cdk"
 
       - name: Wait for documentation CloudFormation stack to idle
@@ -102,5 +102,5 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
-      - name: Deploy documentation stack
+      - name: Deploy documentation CloudFormation stack
         run: pnpm run deploy --filter="docs-cdk"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,7 +16,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: staging-${{ github.head_ref }}
+  group: deploy-staging-${{ github.head_ref }}
   cancel-in-progress: true
 
 env:
@@ -43,10 +43,10 @@ jobs:
       url: https://staging-${{ github.event.pull_request.number }}.api-next.peterportal.org
 
     steps:
-      - name: Check out codebase
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install dependencies
@@ -83,10 +83,10 @@ jobs:
       url: https://staging-${{ github.event.pull_request.number }}-docs.api-next.peterportal.org
 
     steps:
-      - name: Check out codebase
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install dependencies

--- a/.github/workflows/destroy-staging.yml
+++ b/.github/workflows/destroy-staging.yml
@@ -9,7 +9,7 @@ on:
       - labeled
 
 concurrency:
-  group: destroy-staging-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/destroy-staging.yml
+++ b/.github/workflows/destroy-staging.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   destroy-api:
-    name: Destroy API CloudFormation stacks and staging environment for pull request
+    name: Destroy API CloudFormation stack and staging environment for pull request
 
     if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'
 
@@ -72,7 +72,7 @@ jobs:
           onlyDeactivateDeployments: true
 
   cleanup-documentation:
-    name: Destroy documentation CloudFormation stacks and staging environment for pull request
+    name: Destroy documentation CloudFormation stack and staging environment for pull request
 
     if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'
 

--- a/.github/workflows/destroy-staging.yml
+++ b/.github/workflows/destroy-staging.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
 ---
-name: Clean up staging environments for pull request
+name: Cleanup staging environment for pull request
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
       - labeled
 
 concurrency:
-  group: cleanup-${{ github.head_ref }}
+  group: cleanup-staging-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:
@@ -32,17 +32,17 @@ env:
 
 jobs:
   cleanup-api:
-    name: Clean up API staging environment for pull request
+    name: Cleanup API staging environment for pull request
 
     if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out codebase
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
       - name: Destroy API stack
         run: pnpm destroy --filter="ant-stack"
 
-      - name: Set API staging environment as inactive
+      - name: Set API staging environment to inactive
         uses: strumwolf/delete-deployment-environment@v2.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -79,10 +79,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out codebase
+      - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install dependencies
@@ -101,7 +101,7 @@ jobs:
       - name: Destroy documentation stack
         run: pnpm destroy --filter="docs-cdk"
 
-      - name: Set environment as inactive
+      - name: Set documentation staging environment as inactive
         uses: strumwolf/delete-deployment-environment@v2.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/destroy-staging.yml
+++ b/.github/workflows/destroy-staging.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
 ---
-name: Cleanup staging environment for pull request
+name: Destroy CloudFormation stacks and staging environment for pull request
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
       - labeled
 
 concurrency:
-  group: cleanup-staging-${{ github.head_ref }}
+  group: destroy-staging-${{ github.head_ref }}
   cancel-in-progress: true
 
 permissions:
@@ -31,8 +31,8 @@ env:
   PR_NUM: ${{ github.event.pull_request.number }}
 
 jobs:
-  cleanup-api:
-    name: Cleanup API staging environment for pull request
+  destroy-api:
+    name: Destroy API CloudFormation stacks and staging environment for pull request
 
     if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'
 
@@ -61,7 +61,7 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
-      - name: Destroy API stack
+      - name: Destroy API CloudFormation stack
         run: pnpm destroy --filter="ant-stack"
 
       - name: Set API staging environment to inactive
@@ -72,7 +72,7 @@ jobs:
           onlyDeactivateDeployments: true
 
   cleanup-documentation:
-    name: Clean up documentation staging environment for pull request
+    name: Destroy documentation CloudFormation stacks and staging environment for pull request
 
     if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'
 
@@ -98,7 +98,7 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRETS_ACCESS_KEY }}
 
-      - name: Destroy documentation stack
+      - name: Destroy documentation CloudFormation stack
         run: pnpm destroy --filter="docs-cdk"
 
       - name: Set documentation staging environment as inactive


### PR DESCRIPTION
# Summary
- It turns out the "most correct" spelling for Node is `Node.js` :shrug:
- The group name used is just the workflow name + ref
- Checking out the repository is always named "Checkout repository"
- Always specify "CloudFormation" stack
  - "stack" by itself is vague; but like the only people that work on this are people that know what it means :shrug: