### PR TITLE
fix: 🐛 use the custom devmoji config

### DIFF
--- a/.github/workflows/destroy-staging.yml
+++ b/.github/workflows/destroy-staging.yml
@@ -75,7 +75,7 @@ jobs:
           environment: staging-${{ github.event.pull_request.number }}
           onlyDeactivateDeployments: true
 
-  cleanup-documentation:
+  destroy-documentation:
     name: Destroy documentation CloudFormation stack and staging environment for pull request
 
     if: (github.event.action == 'labeled' && github.event.label.name == 'no deploy') || github.event.action == 'closed'

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Format pull request title
         id: devmoji
         run: |
-          TITLE=$(npx --no -- devmoji --format shortcode --text ${{ toJSON(github.event.pull_request.title) }})
+          TITLE=$(npx --no -- devmoji --config devmoji.config.cjs --format shortcode --text ${{ toJSON(github.event.pull_request.title) }})
           echo "TITLE=$TITLE" >> $GITHUB_OUTPUT
 
       - name: Update pull request title if needed

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check out codebase
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
 
-      - name: Setup NodeJS and pnpm
+      - name: Setup Node.js and pnpm
         uses: ./.github/actions/setup-node-and-pnpm
 
       - name: Install devDependencies
@@ -35,7 +35,7 @@ jobs:
       - name: Format pull request title
         id: devmoji
         run: |
-          TITLE=$(npx --no -- devmoji --config devmoji.config.cjs --format shortcode --text ${{ toJSON(github.event.pull_request.title) }})
+          TITLE=$(npx --no -- devmoji --config devmoji.config.cjs --text ${{ toJSON(github.event.pull_request.title) }})
           echo "TITLE=$TITLE" >> $GITHUB_OUTPUT
 
       - name: Update pull request title if needed

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx --no -- commitlint --edit
-npx --no -- devmoji --edit --format shortcode
+npx --no -- devmoji --edit --format shortcode --config devmoji.config.cjs

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,4 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx --no -- commitlint --edit
-npx --no -- devmoji --edit --format shortcode --config devmoji.config.cjs
+npx --no -- devmoji --edit --config devmoji.config.cjs

--- a/devmoji.config.cjs
+++ b/devmoji.config.cjs
@@ -1,6 +1,112 @@
 // @ts-check
 
 /**
+ * @type {import('devmoji/lib/config-options').TDevmoji[]}
+ */
+const devmoji = [
+  {
+    code: "feat",
+    description: "a new feature",
+    emoji: "sparkles",
+  },
+  {
+    code: "fix",
+    description: "a bug fix",
+    emoji: "bug",
+  },
+  {
+    code: "docs",
+    description: "documentation only changes",
+    emoji: "books",
+  },
+  {
+    code: "style",
+    description:
+      "changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
+    emoji: "art",
+  },
+  {
+    code: "refactor",
+    description: "a code change that neither fixes a bug nor adds a feature",
+    emoji: "recycle",
+  },
+  {
+    code: "perf",
+    description: "a code change that improves performance",
+    emoji: "zap",
+  },
+  {
+    code: "test",
+    description: "adding missing or correcting existing tests",
+    emoji: "rotating_light",
+  },
+  {
+    code: "chore",
+    description:
+      "changes to the build process or auxiliary tools and libraries such as documentation generation",
+    emoji: "wrench",
+  },
+  {
+    code: "chore-release",
+    description: "code deployment or publishing to external repositories",
+    emoji: "rocket",
+  },
+  {
+    code: "chore-deps",
+    description: "add or delete dependencies",
+    emoji: "link",
+  },
+  {
+    code: "build",
+    description: "changes related to build processes",
+    emoji: "package",
+  },
+  {
+    code: "ci",
+    description: "updates to the continuous integration system",
+    emoji: "construction_worker",
+  },
+  {
+    code: "release",
+    description: "code deployment or publishing to external repositories",
+    emoji: "rocket",
+  },
+
+  {
+    code: "security",
+    gitmoji: "lock",
+  },
+  {
+    code: "i18n",
+    gitmoji: "globe_with_meridians",
+  },
+  {
+    code: "breaking",
+    gitmoji: "boom",
+  },
+  {
+    code: "config",
+    gitmoji: "wrench",
+    emoji: "gear",
+  },
+  {
+    code: "add",
+    emoji: "heavy_plus_sign",
+    description: "add something",
+  },
+  {
+    code: "remove",
+    emoji: "heavy_minus_sign",
+    description: "remove something",
+  },
+  {
+    code: "revert",
+    emoji: "rewind",
+    description: "revert changes",
+  },
+];
+
+/**
  * Based on the default configuration from devmoji.
  *
  * @see https://github.com/folke/devmoji/blob/master/src/config-options-defaults.ts
@@ -8,121 +114,8 @@
  * @type {import('devmoji/lib/config-options').ConfigOptions}
  */
 const config = {
-  types: [
-    "feat",
-    "fix",
-    "docs",
-    "style",
-    "refactor",
-    "perf",
-    "test",
-    "chore",
-    "build",
-    "ci",
-    "revert",
-  ],
-  devmoji: [
-    {
-      code: "feat",
-      description: "a new feature",
-      emoji: "sparkles",
-    },
-    {
-      code: "fix",
-      description: "a bug fix",
-      emoji: "bug",
-    },
-    {
-      code: "docs",
-      description: "documentation only changes",
-      emoji: "books",
-    },
-    {
-      code: "style",
-      description:
-        "changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
-      emoji: "art",
-    },
-    {
-      code: "refactor",
-      description: "a code change that neither fixes a bug nor adds a feature",
-      emoji: "recycle",
-    },
-    {
-      code: "perf",
-      description: "a code change that improves performance",
-      emoji: "zap",
-    },
-    {
-      code: "test",
-      description: "adding missing or correcting existing tests",
-      emoji: "rotating_light",
-    },
-    {
-      code: "chore",
-      description:
-        "changes to the build process or auxiliary tools and libraries such as documentation generation",
-      emoji: "wrench",
-    },
-    {
-      code: "chore-release",
-      description: "code deployment or publishing to external repositories",
-      emoji: "rocket",
-    },
-    {
-      code: "chore-deps",
-      description: "add or delete dependencies",
-      emoji: "link",
-    },
-    {
-      code: "build",
-      description: "changes related to build processes",
-      emoji: "package",
-    },
-    {
-      code: "ci",
-      description: "updates to the continuous integration system",
-      emoji: "construction_worker",
-    },
-    {
-      code: "release",
-      description: "code deployment or publishing to external repositories",
-      emoji: "rocket",
-    },
-
-    {
-      code: "security",
-      gitmoji: "lock",
-    },
-    {
-      code: "i18n",
-      gitmoji: "globe_with_meridians",
-    },
-    {
-      code: "breaking",
-      gitmoji: "boom",
-    },
-    {
-      code: "config",
-      gitmoji: "wrench",
-      emoji: "gear",
-    },
-    {
-      code: "add",
-      emoji: "heavy_plus_sign",
-      description: "add something",
-    },
-    {
-      code: "remove",
-      emoji: "heavy_minus_sign",
-      description: "remove something",
-    },
-    {
-      code: "revert",
-      emoji: "rewind",
-      description: "revert changes",
-    },
-  ],
+  types: devmoji.map((devmoji) => devmoji.code),
+  devmoji,
 };
 
 module.exports = config;

--- a/devmoji.config.cjs
+++ b/devmoji.config.cjs
@@ -8,7 +8,19 @@
  * @type {import('devmoji/lib/config-options').ConfigOptions}
  */
 const config = {
-  types: ["feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "build", "ci"],
+  types: [
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "perf",
+    "test",
+    "chore",
+    "build",
+    "ci",
+    "revert",
+  ],
   devmoji: [
     {
       code: "feat",
@@ -104,6 +116,11 @@ const config = {
       code: "remove",
       emoji: "heavy_minus_sign",
       description: "remove something",
+    },
+    {
+      code: "revert",
+      emoji: "rewind",
+      description: "revert changes",
     },
   ],
 };


### PR DESCRIPTION
# Summary
It turns out `devmoji` specifically reads from `devmoji.config.js` not from any variants like `devmoji.config.cjs` by default. This incorrect behavior can be verified by adding adding a `revert` entry in the config, and creating a Git commit message with "revert" as the type -- it doesn't pick up the new entry.

- Added a `revert` type
- Made the `types` config property derived from the emojis supported.
- Use real emojis instead of shortcode ones