### PR TITLE
feat: ✨ restore deployment feature parity

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ const config = {
   root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: ["./tsconfig.json", "./apps/docs/tsconfig.json", "./apps/docs/cdk/tsconfig.json"],
+    project: ["./tsconfig.json", "./apps/docs/tsconfig.json"],
     sourceType: "module",
   },
   plugins: ["import", "@typescript-eslint"],
@@ -38,7 +38,7 @@ const config = {
       },
     ],
   },
-  ignorePatterns: ["*.config.*", "*.cjs"],
+  ignorePatterns: ["*.cjs"],
   env: {
     es2020: true,
     node: true,

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -95,7 +95,7 @@ class ApiStack extends Stack {
         format: "esm",
         platform: "node",
         bundle: true,
-        minify: true,
+        // minify: true,
         banner: { js },
         outExtension: { ".js": ".mjs" },
         plugins: [

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -160,6 +160,9 @@ class ApiStack extends Stack {
 }
 
 function getStage() {
+  if (!process.env.NODE_ENV) {
+    throw new Error("NODE_ENV not set.");
+  }
   switch (process.env.NODE_ENV) {
     case "production":
       return "prod";
@@ -181,10 +184,6 @@ export async function main() {
   const id = "peterportal-api-next";
 
   const app = new App();
-
-  if (!process.env.NODE_ENV) {
-    throw new Error("NODE_ENV not set.");
-  }
 
   const stage = getStage();
 

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -23,7 +23,7 @@ const js = `
 
   const require = topLevelModule.createRequire(import.meta.url);
   const __filename = topLevelUrl.fileURLToPath(import.meta.url);
-  const __dirname = topLeveldirname(__filename);
+  const __dirname = topLevelPath.dirname(__filename);
 `;
 
 const projectRoot = process.cwd();

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -47,8 +47,7 @@ class ApiStack extends Stack {
       plugins: createApiCliPlugins({
         dev: {
           hooks: {
-            transformExpressParams: (params) => {
-              const { req } = params;
+            transformExpressParams: ({ req }) => {
               logger.info(`Path params: ${JSON.stringify(req.params)}`);
               logger.info(`Query: ${JSON.stringify(req.query)}`);
               logger.info(`Body: ${JSON.stringify(req.body)}`);
@@ -59,9 +58,7 @@ class ApiStack extends Stack {
       }),
       exitPoint: "handler.mjs",
       constructs: {
-        functionPlugin: (functionResources) => {
-          const { functionProps, handler } = functionResources;
-
+        functionPlugin: ({ functionProps, handler }) => {
           const warmingTarget = new LambdaFunction(handler, {
             event: RuleTargetInput.fromObject({ body: "warming request" }),
           });
@@ -85,7 +82,7 @@ class ApiStack extends Stack {
               fs.rmSync(path.join(directory, queryEngineFile));
             });
         },
-        restApiProps: (scope, id) => ({
+        restApiProps: (scope) => ({
           domainName: {
             domainName: `${stage === "prod" ? "" : `${stage}.`}api-next.peterportal.org`,
             certificate: Certificate.fromCertificateArn(

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -42,7 +42,7 @@ class ApiStack extends Stack {
   constructor(scope: App, id: string, stage: string) {
     super(scope, id);
 
-    this.api = new Api(this, `${id}-api`, {
+    this.api = new Api(this, id, {
       directory: "src/routes",
       plugins: createApiCliPlugins({
         dev: {
@@ -188,7 +188,7 @@ export async function main() {
 
   const stage = getStage();
 
-  const stack = new ApiStack(app, id, stage);
+  const stack = new ApiStack(app, `${id}-${stage}`, stage);
 
   const api = stack.api;
 

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -241,7 +241,13 @@ export async function main() {
       }),
     );
 
-    result.api.methods.forEach((x) => x.resource.addMethod("OPTIONS", optionsIntegration));
+    result.api.methods.forEach((x) => {
+      try {
+        x.resource.addMethod("OPTIONS", optionsIntegration);
+      } catch {
+        // no-op
+      }
+    });
   }
 
   return app;

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -84,15 +84,7 @@ class ApiStack extends Stack {
               rmSync(join(directory, queryEngineFile));
             });
         },
-        restApiProps: (scope) => ({
-          domainName: {
-            domainName: `${stage === "prod" ? "" : `${stage}.`}api-next.peterportal.org`,
-            certificate: Certificate.fromCertificateArn(
-              scope,
-              "peterportal-cert",
-              process.env.CERTIFICATE_ARN ?? "",
-            ),
-          },
+        restApiProps: () => ({
           disableExecuteApiEndpoint: true,
           endpointTypes: [EndpointType.EDGE],
           binaryMediaTypes: ["*/*"],
@@ -249,6 +241,15 @@ export async function main() {
       } catch {
         // no-op
       }
+    });
+
+    result.api.addDomainName(`${id}-${stage}-domain`, {
+      domainName: `${stage === "prod" ? "" : `${stage}.`}api-next.peterportal.org`,
+      certificate: Certificate.fromCertificateArn(
+        result.api,
+        "peterportal-cert",
+        process.env.CERTIFICATE_ARN ?? "",
+      ),
     });
 
     new ARecord(result.api, `${id}-${stage}-a-record`, {

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -229,25 +229,19 @@ export async function main() {
       },
     });
 
-    // let optionsIntegration: LambdaIntegration;
-
-    result.api.root.addMethod(
-      "OPTIONS",
-      /* optionsIntegration = */ new LambdaIntegration(
-        new lambda.Function(result.api, `${id}-options-handler`, {
-          code: Code.fromInline(
-            // language=JavaScript
-            'exports.h=async _=>({body:"",headers:{"Access-Control-Allow-Origin":"*","Access-Control-Allow-Headers":"Apollo-Require-Preflight,Content-Type","Access-Control-Allow-Methods":"GET,POST,OPTIONS"},statusCode:204});',
-          ),
-          handler: "index.h",
-          runtime: Runtime.NODEJS_18_X,
-          architecture: Architecture.ARM_64,
-        }),
-      ),
+    const optionsIntegration = new LambdaIntegration(
+      new lambda.Function(result.api, `${id}-options-handler`, {
+        code: Code.fromInline(
+          // language=JavaScript
+          'exports.h=async _=>({body:"",headers:{"Access-Control-Allow-Origin":"*","Access-Control-Allow-Headers":"Apollo-Require-Preflight,Content-Type","Access-Control-Allow-Methods":"GET,POST,OPTIONS"},statusCode:204});',
+        ),
+        handler: "index.h",
+        runtime: Runtime.NODEJS_18_X,
+        architecture: Architecture.ARM_64,
+      }),
     );
 
-    console.log(JSON.stringify(result.api.methods.map((x) => x.toString())));
-    // result.api.methods.forEach((x) => x.resource.addMethod("OPTIONS", optionsIntegration));
+    result.api.methods.forEach((x) => x.resource.addMethod("OPTIONS", optionsIntegration));
   }
 
   return app;

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -246,7 +246,7 @@ export async function main() {
       ),
     );
 
-    console.log(JSON.stringify(result.api.methods));
+    console.log(JSON.stringify(result.api.methods.map((x) => x.toString())));
     // result.api.methods.forEach((x) => x.resource.addMethod("OPTIONS", optionsIntegration));
   }
 

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, cpSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { Api } from "@bronya.js/api-construct";
@@ -99,22 +99,6 @@ class ApiStack extends Stack {
         banner: { js },
         outExtension: { ".js": ".mjs" },
         plugins: [
-          {
-            name: "copy-graphql-schema",
-            setup(build) {
-              build.onStart(async () => {
-                if (!build.initialOptions.outdir?.endsWith("graphql")) return;
-
-                mkdirSync(build.initialOptions.outdir, { recursive: true });
-
-                cpSync(
-                  resolve(projectRoot, "src/routes/v1/graphql/schema"),
-                  join(build.initialOptions.outdir, "schema"),
-                  { recursive: true },
-                );
-              });
-            },
-          },
           {
             name: "copy-prisma",
             setup(build) {

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -229,11 +229,11 @@ export async function main() {
       },
     });
 
-    let optionsIntegration: LambdaIntegration;
+    // let optionsIntegration: LambdaIntegration;
 
     result.api.root.addMethod(
       "OPTIONS",
-      (optionsIntegration = new LambdaIntegration(
+      /* optionsIntegration = */ new LambdaIntegration(
         new lambda.Function(result.api, `${id}-options-handler`, {
           code: Code.fromInline(
             // language=JavaScript
@@ -243,10 +243,11 @@ export async function main() {
           runtime: Runtime.NODEJS_18_X,
           architecture: Architecture.ARM_64,
         }),
-      )),
+      ),
     );
 
-    result.api.methods.forEach((x) => x.resource.addMethod("OPTIONS", optionsIntegration));
+    console.log(JSON.stringify(result.api.methods));
+    // result.api.methods.forEach((x) => x.resource.addMethod("OPTIONS", optionsIntegration));
   }
 
   return app;

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -5,7 +5,7 @@ import { Api } from "@bronya.js/api-construct";
 import { createApiCliPlugins } from "@bronya.js/api-construct/plugins/cli";
 import { isCdk } from "@bronya.js/core";
 import { logger } from "@libs/lambda";
-import { EndpointType, LambdaIntegration, ResponseType } from "aws-cdk-lib/aws-apigateway";
+import { LambdaIntegration, ResponseType } from "aws-cdk-lib/aws-apigateway";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { RuleTargetInput, Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
@@ -84,12 +84,7 @@ class ApiStack extends Stack {
               rmSync(join(directory, queryEngineFile));
             });
         },
-        restApiProps: () => ({
-          disableExecuteApiEndpoint: true,
-          endpointTypes: [EndpointType.EDGE],
-          binaryMediaTypes: ["*/*"],
-          restApiName: `${id}-${stage}`,
-        }),
+        restApiProps: () => ({ disableExecuteApiEndpoint: true, binaryMediaTypes: ["*/*"] }),
       },
       environment: {
         DATABASE_URL: process.env["DATABASE_URL"] ?? "",
@@ -125,6 +120,8 @@ class ApiStack extends Stack {
             setup(build) {
               build.onStart(async () => {
                 const outDirectory = build.initialOptions.outdir ?? projectRoot;
+
+                if (outDirectory.endsWith("graphql")) return;
 
                 mkdirSync(outDirectory, { recursive: true });
 
@@ -266,5 +263,6 @@ export async function main() {
 }
 
 if (isCdk()) {
-  await main();
+  // Sike, looks like even though we have top-level await, the dev server won't start with it :(
+  main().then();
 }

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -193,12 +193,6 @@ export async function main() {
 
     const result = await api.synth();
 
-    const responseHeaders = {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Headers": "Apollo-Require-Preflight,Content-Type",
-      "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
-    };
-
     /**
      * Add gateway responses for 5xx and 404 errors, so that they remain compliant
      * with the {@link `ErrorResponse`} type.
@@ -206,7 +200,6 @@ export async function main() {
     result.api.addGatewayResponse(`${id}-${stage}-5xx`, {
       type: ResponseType.DEFAULT_5XX,
       statusCode: "500",
-      responseHeaders,
       templates: {
         "application/json": JSON.stringify({
           timestamp: "$context.requestTime",
@@ -220,7 +213,6 @@ export async function main() {
     result.api.addGatewayResponse(`${id}-${stage}-404`, {
       type: ResponseType.MISSING_AUTHENTICATION_TOKEN,
       statusCode: "404",
-      responseHeaders,
       templates: {
         "application/json": JSON.stringify({
           timestamp: "$context.requestTime",
@@ -240,7 +232,7 @@ export async function main() {
       new AwsLambdaFunction(result.api, `${id}-${stage}-options-handler`, {
         code: Code.fromInline(
           // language=JavaScript
-          `exports.h=async _=>({body:"",headers:${JSON.stringify(responseHeaders)});`,
+          'exports.h=async _=>({headers:{"Access-Control-Allow-Origin": "*","Access-Control-Allow-Headers": "Apollo-Require-Preflight,Content-Type","Access-Control-Allow-Methods": "GET,POST,OPTIONS"},statusCode:204})',
         ),
         handler: "index.h",
         runtime: Runtime.NODEJS_18_X,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,8 +39,8 @@
     "zod": "3.22.2"
   },
   "devDependencies": {
-    "@bronya.js/api-construct": "0.11.0",
-    "@bronya.js/core": "0.11.0",
+    "@bronya.js/api-construct": "0.11.1",
+    "@bronya.js/core": "0.11.1",
     "@types/aws-lambda": "8.10.119",
     "aws-cdk": "2.93.0",
     "dotenv": "16.3.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,8 +38,8 @@
     "zod": "3.22.2"
   },
   "devDependencies": {
-    "@bronya.js/api-construct": "0.11.2",
-    "@bronya.js/core": "0.11.2",
+    "@bronya.js/api-construct": "0.11.3",
+    "@bronya.js/core": "0.11.3",
     "@types/aws-lambda": "8.10.119",
     "aws-cdk": "2.93.0",
     "dotenv": "16.3.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,8 +39,8 @@
     "zod": "3.22.2"
   },
   "devDependencies": {
-    "@bronya.js/api-construct": "0.10.9",
-    "@bronya.js/core": "0.10.9",
+    "@bronya.js/api-construct": "0.10.11",
+    "@bronya.js/core": "0.10.11",
     "@types/aws-lambda": "8.10.119",
     "aws-cdk": "2.93.0",
     "dotenv": "16.3.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,8 +39,8 @@
     "zod": "3.22.2"
   },
   "devDependencies": {
-    "@bronya.js/api-construct": "0.10.11",
-    "@bronya.js/core": "0.10.11",
+    "@bronya.js/api-construct": "0.11.0",
+    "@bronya.js/core": "0.11.0",
     "@types/aws-lambda": "8.10.119",
     "aws-cdk": "2.93.0",
     "dotenv": "16.3.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,6 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "bronya.config.ts",
   "scripts": {
     "cdk-app": "cdk --app 'npx tsx bronya.config.ts' --require-approval never",
     "dev": "bunny dev-api"
@@ -39,8 +38,8 @@
     "zod": "3.22.2"
   },
   "devDependencies": {
-    "@bronya.js/api-construct": "0.11.1",
-    "@bronya.js/core": "0.11.1",
+    "@bronya.js/api-construct": "0.11.2",
+    "@bronya.js/core": "0.11.2",
     "@types/aws-lambda": "8.10.119",
     "aws-cdk": "2.93.0",
     "dotenv": "16.3.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "aws-cdk": "2.93.0",
     "dotenv": "16.3.1",
     "dotenv-cli": "7.3.0",
+    "esbuild": "0.19.2",
     "tsx": "3.12.7"
   },
   "//": "the CDK configuration in this config file is used in the deployment package, @tools/cdk"

--- a/apps/api/src/routes/v1/graphql/+config.ts
+++ b/apps/api/src/routes/v1/graphql/+config.ts
@@ -3,40 +3,21 @@ import { join, resolve } from "node:path";
 
 import { ApiPropsOverride } from "@bronya.js/api-construct";
 
-/**
- * @see https://github.com/evanw/esbuild/issues/1921#issuecomment-1623640043
- */
-// language=JavaScript
-const js = `
-  import topLevelModule from "node:module";
-  import topLevelUrl from "node:url";
-  import topLevelPath from "node:path";
-
-  const require = topLevelModule.createRequire(import.meta.url);
-  const __filename = topLevelUrl.fileURLToPath(import.meta.url);
-  const __dirname = topLevelPath.dirname(__filename);
-`;
+import { esbuildOptions } from "../../../../bronya.config";
 
 export const overrides: ApiPropsOverride = {
   esbuild: {
-    format: "esm",
-    platform: "node",
-    bundle: true,
-    minify: true,
-    banner: { js },
-    outExtension: { ".js": ".mjs" },
+    ...esbuildOptions,
     plugins: [
       {
         name: "copy-graphql-schema",
         setup(build) {
           build.onStart(async () => {
-            if (!build.initialOptions.outdir?.endsWith("graphql")) return;
-
-            mkdirSync(build.initialOptions.outdir, { recursive: true });
+            mkdirSync(build.initialOptions.outdir!, { recursive: true });
 
             cpSync(
               resolve("src/routes/v1/graphql/schema"),
-              join(build.initialOptions.outdir, "schema"),
+              join(build.initialOptions.outdir!, "schema"),
               {
                 recursive: true,
               },

--- a/apps/api/src/routes/v1/graphql/+config.ts
+++ b/apps/api/src/routes/v1/graphql/+config.ts
@@ -1,0 +1,45 @@
+import { cpSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { ApiPropsOverride } from "@bronya.js/api-construct";
+
+/**
+ * @see https://github.com/evanw/esbuild/issues/1921#issuecomment-1623640043
+ */
+// language=JavaScript
+const js = `
+  import topLevelModule from "node:module";
+  import topLevelUrl from "node:url";
+  import topLevelPath from "node:path";
+
+  const require = topLevelModule.createRequire(import.meta.url);
+  const __filename = topLevelUrl.fileURLToPath(import.meta.url);
+  const __dirname = topLevelPath.dirname(__filename);
+`;
+
+export const overrides: ApiPropsOverride = {
+  esbuild: {
+    format: "esm",
+    platform: "node",
+    bundle: true,
+    minify: true,
+    banner: { js },
+    outExtension: { ".js": ".mjs" },
+    plugins: [
+      {
+        name: "copy-graphql-schema",
+        setup(build) {
+          build.onStart(async () => {
+            if (!build.initialOptions.outdir?.endsWith("graphql")) return;
+
+            mkdirSync(build.initialOptions.outdir, { recursive: true });
+
+            cpSync(resolve("./schema"), join(build.initialOptions.outdir, "schema"), {
+              recursive: true,
+            });
+          });
+        },
+      },
+    ],
+  },
+};

--- a/apps/api/src/routes/v1/graphql/+config.ts
+++ b/apps/api/src/routes/v1/graphql/+config.ts
@@ -34,9 +34,13 @@ export const overrides: ApiPropsOverride = {
 
             mkdirSync(build.initialOptions.outdir, { recursive: true });
 
-            cpSync(resolve("./schema"), join(build.initialOptions.outdir, "schema"), {
-              recursive: true,
-            });
+            cpSync(
+              resolve("src/routes/v1/graphql/schema"),
+              join(build.initialOptions.outdir, "schema"),
+              {
+                recursive: true,
+              },
+            );
           });
         },
       },

--- a/apps/api/src/routes/v1/graphql/+endpoint.ts
+++ b/apps/api/src/routes/v1/graphql/+endpoint.ts
@@ -40,16 +40,12 @@ export const ANY: APIGatewayProxyHandler = async (event) => {
     await graphqlServer.start();
   }
 
-  let headers: HeaderMap;
   const req: HTTPGraphQLRequest = {
     body,
-    get headers() {
-      headers ??= Object.entries(eventHeaders).reduce(
-        (m, [k, v]) => m.set(k, Array.isArray(v) ? v.join(", ") : v ?? ""),
-        new HeaderMap(),
-      );
-      return headers;
-    },
+    headers: Object.entries(eventHeaders).reduce(
+      (m, [k, v]) => m.set(k, Array.isArray(v) ? v.join(", ") : v ?? ""),
+      new HeaderMap(),
+    ),
     method,
     search: parse(event.path ?? "").search ?? "",
   };

--- a/apps/api/src/routes/v1/graphql/+endpoint.ts
+++ b/apps/api/src/routes/v1/graphql/+endpoint.ts
@@ -32,8 +32,9 @@ const graphqlServer = new ApolloServer({
 });
 
 export const ANY: APIGatewayProxyHandler = async (event) => {
-  const { body, headers: eventHeaders, httpMethod: method } = event;
+  const { body, headers: eventHeaders, multiValueHeaders, httpMethod: method } = event;
   logger.info(eventHeaders);
+  logger.info(multiValueHeaders);
 
   try {
     graphqlServer.assertStarted("");
@@ -43,7 +44,7 @@ export const ANY: APIGatewayProxyHandler = async (event) => {
 
   const req: HTTPGraphQLRequest = {
     body,
-    headers: Object.entries(eventHeaders).reduce(
+    headers: Object.entries(eventHeaders ?? { "content-encoding": "application/json" }).reduce(
       (m, [k, v]) => m.set(k, Array.isArray(v) ? v.join(", ") : v ?? ""),
       new HeaderMap(),
     ),

--- a/apps/api/src/routes/v1/graphql/+endpoint.ts
+++ b/apps/api/src/routes/v1/graphql/+endpoint.ts
@@ -8,7 +8,7 @@ import {
 } from "@apollo/server/plugin/landingPage/default";
 import { loadFilesSync } from "@graphql-tools/load-files";
 import { mergeTypeDefs } from "@graphql-tools/merge";
-import { compress } from "@libs/lambda";
+import { compress, logger } from "@libs/lambda";
 import type { APIGatewayProxyHandler, APIGatewayProxyResult } from "aws-lambda";
 
 import { transformBody } from "./lib";
@@ -49,6 +49,7 @@ export const ANY: APIGatewayProxyHandler = async (event) => {
     method,
     search: parse(event.path ?? "").search ?? "",
   };
+  logger.info(JSON.stringify(req));
   const res = await graphqlServer.executeHTTPGraphQLRequest({
     httpGraphQLRequest: req,
     context: async () => ({}),

--- a/apps/api/src/routes/v1/graphql/+endpoint.ts
+++ b/apps/api/src/routes/v1/graphql/+endpoint.ts
@@ -33,6 +33,7 @@ const graphqlServer = new ApolloServer({
 
 export const ANY: APIGatewayProxyHandler = async (event) => {
   const { body, headers: eventHeaders, httpMethod: method } = event;
+  logger.info(eventHeaders);
 
   try {
     graphqlServer.assertStarted("");

--- a/apps/api/src/routes/v1/graphql/+endpoint.ts
+++ b/apps/api/src/routes/v1/graphql/+endpoint.ts
@@ -33,8 +33,8 @@ const graphqlServer = new ApolloServer({
 
 export const ANY: APIGatewayProxyHandler = async (event) => {
   const { body, headers: eventHeaders, multiValueHeaders, httpMethod: method } = event;
-  logger.info(eventHeaders);
-  logger.info(multiValueHeaders);
+  logger.info(JSON.stringify(eventHeaders));
+  logger.info(JSON.stringify(multiValueHeaders));
 
   try {
     graphqlServer.assertStarted("");
@@ -44,7 +44,7 @@ export const ANY: APIGatewayProxyHandler = async (event) => {
 
   const req: HTTPGraphQLRequest = {
     body,
-    headers: Object.entries(eventHeaders ?? { "content-encoding": "application/json" }).reduce(
+    headers: Object.entries(eventHeaders).reduce(
       (m, [k, v]) => m.set(k, Array.isArray(v) ? v.join(", ") : v ?? ""),
       new HeaderMap(),
     ),

--- a/apps/api/src/routes/v1/graphql/+endpoint.ts
+++ b/apps/api/src/routes/v1/graphql/+endpoint.ts
@@ -32,9 +32,7 @@ const graphqlServer = new ApolloServer({
 });
 
 export const ANY: APIGatewayProxyHandler = async (event) => {
-  const { body, headers: eventHeaders, multiValueHeaders, httpMethod: method } = event;
-  logger.info(JSON.stringify(eventHeaders));
-  logger.info(JSON.stringify(multiValueHeaders));
+  const { body, headers: eventHeaders, httpMethod: method } = event;
 
   try {
     graphqlServer.assertStarted("");
@@ -43,7 +41,7 @@ export const ANY: APIGatewayProxyHandler = async (event) => {
   }
 
   const req: HTTPGraphQLRequest = {
-    body,
+    body: typeof body === "string" ? JSON.parse(body.replaceAll("\n", "\\n")) : body,
     headers: Object.entries(eventHeaders).reduce(
       (m, [k, v]) => m.set(k, Array.isArray(v) ? v.join(", ") : v ?? ""),
       new HeaderMap(),

--- a/apps/api/src/routes/v1/rest/courses/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/courses/+endpoint.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@libs/db";
-import { createErrorResult, createOKResult } from "@libs/lambda";
+import { createErrorResult, createOKResult, logger } from "@libs/lambda";
 import type { APIGatewayProxyHandler } from "aws-lambda";
 import { ZodError } from "zod";
 
@@ -12,6 +12,8 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
   const headers = event.headers;
   const query = event.queryStringParameters;
   const requestId = context.awsRequestId;
+
+  logger.info(headers);
 
   /**
    * TODO: handle warmer requests.

--- a/apps/api/src/routes/v1/rest/courses/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/courses/+endpoint.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@libs/db";
-import { createErrorResult, createOKResult, logger } from "@libs/lambda";
+import { createErrorResult, createOKResult } from "@libs/lambda";
 import type { APIGatewayProxyHandler } from "aws-lambda";
 import { ZodError } from "zod";
 
@@ -12,8 +12,6 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
   const headers = event.headers;
   const query = event.queryStringParameters;
   const requestId = context.awsRequestId;
-
-  logger.info(headers);
 
   /**
    * TODO: handle warmer requests.

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -8,6 +8,8 @@ import {
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
 
+import { esbuildOptions } from "../../../../../bronya.config";
+
 export const overrides: ApiPropsOverride = {
   constructs: {
     functionProps: (scope, id) => ({
@@ -32,5 +34,8 @@ export const overrides: ApiPropsOverride = {
       }),
     }),
   },
-  // esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
+  esbuild: {
+    ...esbuildOptions,
+    external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"],
+  },
 };

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -39,7 +39,7 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin: ({ scope, functionProps, handler }) => {
+    functionPlugin: ({ functionProps, handler }, scope) => {
       const warmingTarget = new LambdaFunction(handler, {
         event: RuleTargetInput.fromObject({ body: "warming request" }),
       });

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -1,0 +1,35 @@
+import { ApiPropsOverride } from "@bronya.js/api-construct";
+import {
+  Effect,
+  ManagedPolicy,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+
+export const overrides: ApiPropsOverride = {
+  constructs: {
+    functionProps: (scope, id) => ({
+      role: new Role(scope, `${id}-v1-rest-websoc-role`, {
+        assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+        managedPolicies: [
+          ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
+        ],
+        inlinePolicies: {
+          lambdaInvokePolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                effect: Effect.ALLOW,
+                resources: [
+                  `arn:aws:lambda:${process.env["AWS_REGION"]}:${process.env["ACCOUNT_ID"]}:function:peterportal-api-next-services-prod-websoc-proxy-function`,
+                ],
+                actions: ["lambda:InvokeFunction"],
+              }),
+            ],
+          }),
+        },
+      }),
+    }),
+  },
+};

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -39,7 +39,7 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin: ({ functionProps, handler }) => {
+    functionPlugin({ functionProps, handler }) {
       const warmingTarget = new LambdaFunction(handler, {
         event: RuleTargetInput.fromObject({ body: "warming request" }),
       });

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -1,4 +1,9 @@
+import { readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
 import { ApiPropsOverride } from "@bronya.js/api-construct";
+import { Rule, RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import {
   Effect,
   ManagedPolicy,
@@ -7,6 +12,7 @@ import {
   Role,
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
+import { Duration } from "aws-cdk-lib/core";
 
 import { esbuildOptions } from "../../../../../bronya.config";
 
@@ -33,6 +39,31 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
+    functionPlugin: ({ functionProps, handler }) => {
+      const warmingTarget = new LambdaFunction(handler, {
+        event: RuleTargetInput.fromObject({ body: "warming request" }),
+      });
+
+      const warmingRule = new Rule(this, `${functionProps.functionName}-warming-rule`, {
+        schedule: Schedule.rate(Duration.minutes(5)),
+      });
+
+      warmingRule.addTarget(warmingTarget);
+    },
+    lambdaUpload: (directory) => {
+      const queryEngines = readdirSync(directory).filter((x) => x.endsWith(".so.node"));
+
+      if (queryEngines.length === 1) {
+        return;
+      }
+
+      queryEngines
+        .filter((x) => x !== "libquery_engine-linux-arm64-openssl-1.0.x.so.node")
+        .forEach((queryEngineFile) => {
+          rmSync(join(directory, queryEngineFile));
+        });
+    },
+    restApiProps: () => ({ disableExecuteApiEndpoint: true, binaryMediaTypes: ["*/*"] }),
   },
   esbuild: {
     ...esbuildOptions,

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -39,12 +39,12 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin({ functionProps, handler }) {
+    functionPlugin: ({ scope, functionProps, handler }) => {
       const warmingTarget = new LambdaFunction(handler, {
         event: RuleTargetInput.fromObject({ body: "warming request" }),
       });
 
-      const warmingRule = new Rule(this, `${functionProps.functionName}-warming-rule`, {
+      const warmingRule = new Rule(scope, `${functionProps.functionName}-warming-rule`, {
         schedule: Schedule.rate(Duration.minutes(5)),
       });
 

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -32,4 +32,5 @@ export const overrides: ApiPropsOverride = {
       }),
     }),
   },
+  esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
 };

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -32,5 +32,5 @@ export const overrides: ApiPropsOverride = {
       }),
     }),
   },
-  esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
+  // esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
 };

--- a/apps/api/src/routes/v1/rest/websoc/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+endpoint.ts
@@ -1,16 +1,7 @@
-import { ApiPropsOverride } from "@bronya.js/api-construct";
 import { PrismaClient } from "@libs/db";
 import { createErrorResult, createOKResult } from "@libs/lambda";
 import type { WebsocAPIResponse } from "@libs/uc-irvine-api/websoc";
 import { combineAndNormalizeResponses, notNull, sortResponse } from "@libs/websoc-utils";
-import {
-  Effect,
-  ManagedPolicy,
-  PolicyDocument,
-  PolicyStatement,
-  Role,
-  ServicePrincipal,
-} from "aws-cdk-lib/aws-iam";
 import type { APIGatewayProxyHandler } from "aws-lambda";
 import { ZodError } from "zod";
 
@@ -142,31 +133,4 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
     }
     return createErrorResult(400, error, requestId);
   }
-};
-
-// TODO: move this into a separate file.
-export const overrides: ApiPropsOverride = {
-  constructs: {
-    functionProps: (scope, id) => ({
-      role: new Role(scope, `${id}-v1-rest-websoc-role`, {
-        assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
-        managedPolicies: [
-          ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
-        ],
-        inlinePolicies: {
-          lambdaInvokePolicy: new PolicyDocument({
-            statements: [
-              new PolicyStatement({
-                effect: Effect.ALLOW,
-                resources: [
-                  `arn:aws:lambda:${process.env["AWS_REGION"]}:${process.env["ACCOUNT_ID"]}:function:peterportal-api-next-services-prod-websoc-proxy-function`,
-                ],
-                actions: ["lambda:InvokeFunction"],
-              }),
-            ],
-          }),
-        },
-      }),
-    }),
-  },
 };

--- a/apps/api/src/routes/v1/rest/websoc/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+endpoint.ts
@@ -144,30 +144,29 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
   }
 };
 
+// TODO: move this into a separate file.
 export const overrides: ApiPropsOverride = {
   constructs: {
-    functionProps(scope) {
-      return {
-        role: new Role(scope, `canary-v1-rest-websoc-role`, {
-          assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
-          managedPolicies: [
-            ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
-          ],
-          inlinePolicies: {
-            lambdaInvokePolicy: new PolicyDocument({
-              statements: [
-                new PolicyStatement({
-                  effect: Effect.ALLOW,
-                  resources: [
-                    `arn:aws:lambda:${process.env["AWS_REGION"]}:${process.env["ACCOUNT_ID"]}:function:peterportal-api-next-services-prod-websoc-proxy-function`,
-                  ],
-                  actions: ["lambda:InvokeFunction"],
-                }),
-              ],
-            }),
-          },
-        }),
-      };
-    },
+    functionProps: (scope, id) => ({
+      role: new Role(scope, `${id}-v1-rest-websoc-role`, {
+        assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+        managedPolicies: [
+          ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
+        ],
+        inlinePolicies: {
+          lambdaInvokePolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                effect: Effect.ALLOW,
+                resources: [
+                  `arn:aws:lambda:${process.env["AWS_REGION"]}:${process.env["ACCOUNT_ID"]}:function:peterportal-api-next-services-prod-websoc-proxy-function`,
+                ],
+                actions: ["lambda:InvokeFunction"],
+              }),
+            ],
+          }),
+        },
+      }),
+    }),
   },
 };

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -1,4 +1,9 @@
+import { readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
 import { ApiPropsOverride } from "@bronya.js/api-construct";
+import { Rule, RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import {
   Effect,
   ManagedPolicy,
@@ -7,6 +12,7 @@ import {
   Role,
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
+import { Duration } from "aws-cdk-lib/core";
 
 import { esbuildOptions } from "../../../../../../bronya.config";
 
@@ -33,6 +39,31 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
+    functionPlugin: ({ functionProps, handler }) => {
+      const warmingTarget = new LambdaFunction(handler, {
+        event: RuleTargetInput.fromObject({ body: "warming request" }),
+      });
+
+      const warmingRule = new Rule(this, `${functionProps.functionName}-warming-rule`, {
+        schedule: Schedule.rate(Duration.minutes(5)),
+      });
+
+      warmingRule.addTarget(warmingTarget);
+    },
+    lambdaUpload: (directory) => {
+      const queryEngines = readdirSync(directory).filter((x) => x.endsWith(".so.node"));
+
+      if (queryEngines.length === 1) {
+        return;
+      }
+
+      queryEngines
+        .filter((x) => x !== "libquery_engine-linux-arm64-openssl-1.0.x.so.node")
+        .forEach((queryEngineFile) => {
+          rmSync(join(directory, queryEngineFile));
+        });
+    },
+    restApiProps: () => ({ disableExecuteApiEndpoint: true, binaryMediaTypes: ["*/*"] }),
   },
   esbuild: {
     ...esbuildOptions,

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -39,7 +39,7 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin: ({ scope, functionProps, handler }) => {
+    functionPlugin: ({ functionProps, handler }, scope) => {
       const warmingTarget = new LambdaFunction(handler, {
         event: RuleTargetInput.fromObject({ body: "warming request" }),
       });

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -1,0 +1,35 @@
+import { ApiPropsOverride } from "@bronya.js/api-construct";
+import {
+  Effect,
+  ManagedPolicy,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+
+export const overrides: ApiPropsOverride = {
+  constructs: {
+    functionProps: (scope, id) => ({
+      role: new Role(scope, `${id}-v1-rest-websoc-id-role`, {
+        assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+        managedPolicies: [
+          ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
+        ],
+        inlinePolicies: {
+          lambdaInvokePolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                effect: Effect.ALLOW,
+                resources: [
+                  `arn:aws:lambda:${process.env["AWS_REGION"]}:${process.env["ACCOUNT_ID"]}:function:peterportal-api-next-services-prod-websoc-proxy-function`,
+                ],
+                actions: ["lambda:InvokeFunction"],
+              }),
+            ],
+          }),
+        },
+      }),
+    }),
+  },
+};

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -39,7 +39,7 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin: ({ functionProps, handler }) => {
+    functionPlugin({ functionProps, handler }) {
       const warmingTarget = new LambdaFunction(handler, {
         event: RuleTargetInput.fromObject({ body: "warming request" }),
       });

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -39,12 +39,12 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin({ functionProps, handler }) {
+    functionPlugin: ({ scope, functionProps, handler }) => {
       const warmingTarget = new LambdaFunction(handler, {
         event: RuleTargetInput.fromObject({ body: "warming request" }),
       });
 
-      const warmingRule = new Rule(this, `${functionProps.functionName}-warming-rule`, {
+      const warmingRule = new Rule(scope, `${functionProps.functionName}-warming-rule`, {
         schedule: Schedule.rate(Duration.minutes(5)),
       });
 

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -8,6 +8,8 @@ import {
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
 
+import { esbuildOptions } from "../../../../../../bronya.config";
+
 export const overrides: ApiPropsOverride = {
   constructs: {
     functionProps: (scope, id) => ({
@@ -32,5 +34,8 @@ export const overrides: ApiPropsOverride = {
       }),
     }),
   },
-  // esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
+  esbuild: {
+    ...esbuildOptions,
+    external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"],
+  },
 };

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -32,4 +32,5 @@ export const overrides: ApiPropsOverride = {
       }),
     }),
   },
+  esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
 };

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -32,5 +32,5 @@ export const overrides: ApiPropsOverride = {
       }),
     }),
   },
-  esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
+  // esbuild: { external: process.env.NODE_ENV === "development" ? [] : ["@services/websoc-proxy"] },
 };

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+endpoint.ts
@@ -144,9 +144,9 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
 
 export const overrides: ApiPropsOverride = {
   constructs: {
-    functionProps(scope) {
+    functionProps(scope, id) {
       return {
-        role: new Role(scope, `canary-v1-rest-websoc-role`, {
+        role: new Role(scope, `${id}-v1-rest-websoc-id-role`, {
           assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
           managedPolicies: [
             ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+endpoint.ts
@@ -1,14 +1,5 @@
-import { ApiPropsOverride } from "@bronya.js/api-construct";
 import { PrismaClient } from "@libs/db";
 import { createErrorResult, createOKResult } from "@libs/lambda";
-import {
-  Effect,
-  ManagedPolicy,
-  PolicyDocument,
-  PolicyStatement,
-  Role,
-  ServicePrincipal,
-} from "aws-cdk-lib/aws-iam";
 import type { APIGatewayProxyHandler } from "aws-lambda";
 import { ZodError } from "zod";
 
@@ -140,32 +131,4 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
   }
 
   return createErrorResult(400, "Invalid endpoint", requestId);
-};
-
-export const overrides: ApiPropsOverride = {
-  constructs: {
-    functionProps(scope, id) {
-      return {
-        role: new Role(scope, `${id}-v1-rest-websoc-id-role`, {
-          assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
-          managedPolicies: [
-            ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole"),
-          ],
-          inlinePolicies: {
-            lambdaInvokePolicy: new PolicyDocument({
-              statements: [
-                new PolicyStatement({
-                  effect: Effect.ALLOW,
-                  resources: [
-                    `arn:aws:lambda:${process.env["AWS_REGION"]}:${process.env["ACCOUNT_ID"]}:function:peterportal-api-next-services-prod-websoc-proxy-function`,
-                  ],
-                  actions: ["lambda:InvokeFunction"],
-                }),
-              ],
-            }),
-          },
-        }),
-      };
-    },
-  },
 };

--- a/libs/lambda/src/response.ts
+++ b/libs/lambda/src/response.ts
@@ -53,6 +53,10 @@ export function createOKResult<T>(
   try {
     const { body, method } = compress(JSON.stringify(response), requestHeaders["accept-encoding"]);
 
+    if (method) {
+      headers["content-encoding"] = method;
+    }
+
     logger.info("200 OK");
 
     return {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@commitlint/cli": "17.7.1",
     "@commitlint/config-conventional": "17.7.0",
     "@commitlint/types": "17.4.4",
+    "@tsconfig/node18": "^18.2.1",
     "@types/lint-staged": "13.2.0",
     "@types/node": "18.17.12",
     "@typescript-eslint/eslint-plugin": "6.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,11 +136,11 @@ importers:
         version: 3.22.2
     devDependencies:
       '@bronya.js/api-construct':
-        specifier: 0.10.9
-        version: 0.10.9
+        specifier: 0.10.11
+        version: 0.10.11
       '@bronya.js/core':
-        specifier: 0.10.9
-        version: 0.10.9
+        specifier: 0.10.11
+        version: 0.10.11
       '@types/aws-lambda':
         specifier: 8.10.119
         version: 8.10.119
@@ -2986,12 +2986,12 @@ packages:
   /@balena/dockerignore@1.0.2:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
-  /@bronya.js/api-construct@0.10.9:
-    resolution: {integrity: sha512-OfkmE01TMCwX35uOba4v74U1sa2kZASDUGVUZXjR8hJriU55V0QA6QXyE/aovc51SyvqUnOwhhyZAxWhIIl/5A==}
+  /@bronya.js/api-construct@0.10.11:
+    resolution: {integrity: sha512-gSYKSmnKij+J3oxyqagX5sy0CK8Hf5Tp5JhCgWEX6AgcNybDsYKh/lgZKfJuucJ2ZTNsArdlOa6NuByTX92JQA==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dependencies:
-      '@bronya.js/cli': 0.10.9
-      '@bronya.js/core': 0.10.9
+      '@bronya.js/cli': 0.10.11
+      '@bronya.js/core': 0.10.11
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)
@@ -3007,17 +3007,17 @@ packages:
       - supports-color
     dev: true
 
-  /@bronya.js/cli@0.10.9:
-    resolution: {integrity: sha512-se2qMA4ObQnpEStGt4XFYjUolQVrpfdmL/upd7SGX55yr8TBcnKn7bQG14LrGIRymyG0S+wwkC5p0I+rn8s64Q==}
+  /@bronya.js/cli@0.10.11:
+    resolution: {integrity: sha512-PZ4pgFNzTcXetv9Z/cqTq1fdMBB97Xm/1FZYLT8SRUOqkSnK+i0jbUNHhzuJgI7UZ96qcks8siC6pscEHNSftw==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dev: true
 
-  /@bronya.js/core@0.10.9:
-    resolution: {integrity: sha512-RHQ9Qau8eWe40TBTU8kZa/9PdQw9ROrJ5L7BaGK2Cl0gRmRfJauiXXJ6FoKpmX+hFYsd/bxBbzI0rg8zGJ1hFw==}
+  /@bronya.js/core@0.10.11:
+    resolution: {integrity: sha512-lB+pYLgwO1CmdxG3LcEHLoAFLomnCQloeJFPY7z6h/7NKOmWp3Kr8IIVLUsIwCRNHz9OyxVwWlMSIvCryrD2Ag==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     hasBin: true
     dependencies:
-      '@bronya.js/cli': 0.10.9
+      '@bronya.js/cli': 0.10.11
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,11 +136,11 @@ importers:
         version: 3.22.2
     devDependencies:
       '@bronya.js/api-construct':
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.11.2
+        version: 0.11.2
       '@bronya.js/core':
-        specifier: 0.11.1
-        version: 0.11.1
+        specifier: 0.11.2
+        version: 0.11.2
       '@types/aws-lambda':
         specifier: 8.10.119
         version: 8.10.119
@@ -2986,12 +2986,12 @@ packages:
   /@balena/dockerignore@1.0.2:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
-  /@bronya.js/api-construct@0.11.1:
-    resolution: {integrity: sha512-plj7HmXYINDZkDPgEjwf1GYF3bxDOHaxAfQWOLXQUbbQ+a5dqA9bS4jyg61lI/W5FtiwCPXofCfJ2zAP8UulXg==}
+  /@bronya.js/api-construct@0.11.2:
+    resolution: {integrity: sha512-an0CFp2JEdWxe/WudeI0f8s2CbWyFX1oQoYLs6FvbJE/ELohpoiRWagWmJPsrpHEdvlQKMxwbV8zMCxRFYl/Lg==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dependencies:
-      '@bronya.js/cli': 0.11.1
-      '@bronya.js/core': 0.11.1
+      '@bronya.js/cli': 0.11.2
+      '@bronya.js/core': 0.11.2
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)
@@ -3008,17 +3008,17 @@ packages:
       - supports-color
     dev: true
 
-  /@bronya.js/cli@0.11.1:
-    resolution: {integrity: sha512-wF6J211XnZ0nHd3PGuqPnGlbNA+7ZTuD1z7or8d8B6ynk6/h316sU/h6rHeHp9EPb75xJCWx1vp4n+wpw5HeaQ==}
+  /@bronya.js/cli@0.11.2:
+    resolution: {integrity: sha512-wMZ6w9RCnHlAfS+ukRQiPQ3HModnoJLabSC2hbsVB8mi7gnK+BRiRyTeAVGVcRAoVgqbSgg2sUpnC3sZ3VdPQw==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dev: true
 
-  /@bronya.js/core@0.11.1:
-    resolution: {integrity: sha512-/Wz3hevB1ND/DNoK0/4MsclhHBhJ3Pc+JnbYP9i9B935BLMKD2upLucmQn5lNe3AR6P02h+Hpkmjo45r6qsn7Q==}
+  /@bronya.js/core@0.11.2:
+    resolution: {integrity: sha512-zOZmh8fy8rPSBFIwJDVQfdzqfzh7Nru0ja9BkadV3zZeRVd5pq7qiI+QUKm9PFyoAtuJH2Fa3rwtrIjoJpAXiA==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     hasBin: true
     dependencies:
-      '@bronya.js/cli': 0.11.1
+      '@bronya.js/cli': 0.11.2
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)
@@ -3137,7 +3137,7 @@ packages:
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -7341,7 +7341,7 @@ packages:
     dependencies:
       '@types/node': 20.4.7
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
       typescript: 5.2.2
     dev: true
 
@@ -13129,6 +13129,38 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.17.12
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.2.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.1(@types/node@20.4.7)(typescript@5.2.2):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.4.7
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,11 +136,11 @@ importers:
         version: 3.22.2
     devDependencies:
       '@bronya.js/api-construct':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.11.1
+        version: 0.11.1
       '@bronya.js/core':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.11.1
+        version: 0.11.1
       '@types/aws-lambda':
         specifier: 8.10.119
         version: 8.10.119
@@ -2986,12 +2986,12 @@ packages:
   /@balena/dockerignore@1.0.2:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
-  /@bronya.js/api-construct@0.11.0:
-    resolution: {integrity: sha512-iVtW7d+5sci5Ui3a7Lgvq2TwTfogyHfm6eozgd40cNBALCInKWeYExeI0dwbNrNJsaPD9566Zmgh1ruHvnRKTw==}
+  /@bronya.js/api-construct@0.11.1:
+    resolution: {integrity: sha512-plj7HmXYINDZkDPgEjwf1GYF3bxDOHaxAfQWOLXQUbbQ+a5dqA9bS4jyg61lI/W5FtiwCPXofCfJ2zAP8UulXg==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dependencies:
-      '@bronya.js/cli': 0.11.0
-      '@bronya.js/core': 0.11.0
+      '@bronya.js/cli': 0.11.1
+      '@bronya.js/core': 0.11.1
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)
@@ -3002,22 +3002,23 @@ packages:
       cors: 2.8.5
       defu: 6.1.2
       express: 4.18.2
+      fs-extra: 11.1.1
       jiti: 1.19.1
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@bronya.js/cli@0.11.0:
-    resolution: {integrity: sha512-A//Ycloz7iawLPhTlXRUSVAsqLSGO2zxvLNs0FUQQKBc3N79pC2bKEnsE+mBJNfoOghgzDXB8AoojePdcifXlw==}
+  /@bronya.js/cli@0.11.1:
+    resolution: {integrity: sha512-wF6J211XnZ0nHd3PGuqPnGlbNA+7ZTuD1z7or8d8B6ynk6/h316sU/h6rHeHp9EPb75xJCWx1vp4n+wpw5HeaQ==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dev: true
 
-  /@bronya.js/core@0.11.0:
-    resolution: {integrity: sha512-xP11EjuPn/OxBt/EizN6MBhyfwEVjH3YUY6Sl9Z5XQ/wzooYNxqD7Xn3U2G1980gshuN/wWNb0xN6Cbq/9fnKA==}
+  /@bronya.js/core@0.11.1:
+    resolution: {integrity: sha512-/Wz3hevB1ND/DNoK0/4MsclhHBhJ3Pc+JnbYP9i9B935BLMKD2upLucmQn5lNe3AR6P02h+Hpkmjo45r6qsn7Q==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     hasBin: true
     dependencies:
-      '@bronya.js/cli': 0.11.0
+      '@bronya.js/cli': 0.11.1
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,11 +136,11 @@ importers:
         version: 3.22.2
     devDependencies:
       '@bronya.js/api-construct':
-        specifier: 0.10.11
-        version: 0.10.11
+        specifier: 0.11.0
+        version: 0.11.0
       '@bronya.js/core':
-        specifier: 0.10.11
-        version: 0.10.11
+        specifier: 0.11.0
+        version: 0.11.0
       '@types/aws-lambda':
         specifier: 8.10.119
         version: 8.10.119
@@ -2986,12 +2986,12 @@ packages:
   /@balena/dockerignore@1.0.2:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
-  /@bronya.js/api-construct@0.10.11:
-    resolution: {integrity: sha512-gSYKSmnKij+J3oxyqagX5sy0CK8Hf5Tp5JhCgWEX6AgcNybDsYKh/lgZKfJuucJ2ZTNsArdlOa6NuByTX92JQA==}
+  /@bronya.js/api-construct@0.11.0:
+    resolution: {integrity: sha512-iVtW7d+5sci5Ui3a7Lgvq2TwTfogyHfm6eozgd40cNBALCInKWeYExeI0dwbNrNJsaPD9566Zmgh1ruHvnRKTw==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dependencies:
-      '@bronya.js/cli': 0.10.11
-      '@bronya.js/core': 0.10.11
+      '@bronya.js/cli': 0.11.0
+      '@bronya.js/core': 0.11.0
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)
@@ -3007,17 +3007,17 @@ packages:
       - supports-color
     dev: true
 
-  /@bronya.js/cli@0.10.11:
-    resolution: {integrity: sha512-PZ4pgFNzTcXetv9Z/cqTq1fdMBB97Xm/1FZYLT8SRUOqkSnK+i0jbUNHhzuJgI7UZ96qcks8siC6pscEHNSftw==}
+  /@bronya.js/cli@0.11.0:
+    resolution: {integrity: sha512-A//Ycloz7iawLPhTlXRUSVAsqLSGO2zxvLNs0FUQQKBc3N79pC2bKEnsE+mBJNfoOghgzDXB8AoojePdcifXlw==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dev: true
 
-  /@bronya.js/core@0.10.11:
-    resolution: {integrity: sha512-lB+pYLgwO1CmdxG3LcEHLoAFLomnCQloeJFPY7z6h/7NKOmWp3Kr8IIVLUsIwCRNHz9OyxVwWlMSIvCryrD2Ag==}
+  /@bronya.js/core@0.11.0:
+    resolution: {integrity: sha512-xP11EjuPn/OxBt/EizN6MBhyfwEVjH3YUY6Sl9Z5XQ/wzooYNxqD7Xn3U2G1980gshuN/wWNb0xN6Cbq/9fnKA==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     hasBin: true
     dependencies:
-      '@bronya.js/cli': 0.10.11
+      '@bronya.js/cli': 0.11.0
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)
@@ -3136,7 +3136,7 @@ packages:
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -7340,7 +7340,7 @@ packages:
     dependencies:
       '@types/node': 20.4.7
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
       typescript: 5.2.2
     dev: true
 
@@ -13128,6 +13128,38 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.17.12
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.2.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /ts-node@10.9.1(@types/node@20.4.7)(typescript@5.2.2):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    requiresBuild: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.4.7
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       dotenv-cli:
         specifier: 7.3.0
         version: 7.3.0
+      esbuild:
+        specifier: 0.19.2
+        version: 0.19.2
       tsx:
         specifier: 3.12.7
         version: 3.12.7
@@ -3137,7 +3140,7 @@ packages:
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -7341,7 +7344,7 @@ packages:
     dependencies:
       '@types/node': 20.4.7
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
       typescript: 5.2.2
     dev: true
 
@@ -13129,38 +13132,6 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.17.12
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.2.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node@10.9.1(@types/node@20.4.7)(typescript@5.2.2):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.4.7
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,11 +136,11 @@ importers:
         version: 3.22.2
     devDependencies:
       '@bronya.js/api-construct':
-        specifier: 0.11.2
-        version: 0.11.2
+        specifier: 0.11.3
+        version: 0.11.3
       '@bronya.js/core':
-        specifier: 0.11.2
-        version: 0.11.2
+        specifier: 0.11.3
+        version: 0.11.3
       '@types/aws-lambda':
         specifier: 8.10.119
         version: 8.10.119
@@ -2989,12 +2989,12 @@ packages:
   /@balena/dockerignore@1.0.2:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
-  /@bronya.js/api-construct@0.11.2:
-    resolution: {integrity: sha512-an0CFp2JEdWxe/WudeI0f8s2CbWyFX1oQoYLs6FvbJE/ELohpoiRWagWmJPsrpHEdvlQKMxwbV8zMCxRFYl/Lg==}
+  /@bronya.js/api-construct@0.11.3:
+    resolution: {integrity: sha512-ro5/IwJQIv36k0uoYYL/pMzvFYJMlnzBOdeDylet+9T7gbXSjZEt+LKA9QjFGoqDvRl3WOQIJLUfJRollOVXng==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dependencies:
-      '@bronya.js/cli': 0.11.2
-      '@bronya.js/core': 0.11.2
+      '@bronya.js/cli': 0.11.3
+      '@bronya.js/core': 0.11.3
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)
@@ -3011,17 +3011,17 @@ packages:
       - supports-color
     dev: true
 
-  /@bronya.js/cli@0.11.2:
-    resolution: {integrity: sha512-wMZ6w9RCnHlAfS+ukRQiPQ3HModnoJLabSC2hbsVB8mi7gnK+BRiRyTeAVGVcRAoVgqbSgg2sUpnC3sZ3VdPQw==}
+  /@bronya.js/cli@0.11.3:
+    resolution: {integrity: sha512-1FkvlcXR17rfSGo7cDScrxCeC1S3Ib7GJaGTa874tOtrVHZVM7T0ebyPI1lO715BVEvS+hursJElRU9MZsnQOQ==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     dev: true
 
-  /@bronya.js/core@0.11.2:
-    resolution: {integrity: sha512-zOZmh8fy8rPSBFIwJDVQfdzqfzh7Nru0ja9BkadV3zZeRVd5pq7qiI+QUKm9PFyoAtuJH2Fa3rwtrIjoJpAXiA==}
+  /@bronya.js/core@0.11.3:
+    resolution: {integrity: sha512-D5RU9y6o7KSmUjewjPR9ImR61/FQG4Xw42onn2vwiIJzCyQ7qzo1c7ecnbh7AVdldwa698kySRGne5Um/AemOA==}
     engines: {node: '>=18', pnpm: ^8.0.0}
     hasBin: true
     dependencies:
-      '@bronya.js/cli': 0.11.2
+      '@bronya.js/cli': 0.11.3
       acorn: 8.10.0
       acorn-typescript: 1.4.5(acorn@8.10.0)
       aws-cdk-lib: 2.93.0(constructs@10.2.69)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3136,7 +3136,7 @@ packages:
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -7340,7 +7340,7 @@ packages:
     dependencies:
       '@types/node': 20.4.7
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
       typescript: 5.2.2
     dev: true
 
@@ -13128,38 +13128,6 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.17.12
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.2.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node@10.9.1(@types/node@20.4.7)(typescript@5.2.2):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.4.7
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@commitlint/types':
         specifier: 17.4.4
         version: 17.4.4
+      '@tsconfig/node18':
+        specifier: ^18.2.1
+        version: 18.2.1
       '@types/lint-staged':
         specifier: 13.2.0
         version: 13.2.0
@@ -3133,7 +3136,7 @@ packages:
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -5600,6 +5603,10 @@ packages:
     requiresBuild: true
     dev: true
 
+  /@tsconfig/node18@18.2.1:
+    resolution: {integrity: sha512-RDDZFuofwkcKpl8Vpj5wFbY+H53xOtqK7ckEL1sXsbPwvKwDdjQf3LkHbtt9sxIHn9nWIEwkmCwBRZ6z5TKU2A==}
+    dev: true
+
   /@types/aws-lambda@8.10.119:
     resolution: {integrity: sha512-Vqm22aZrCvCd6I5g1SvpW151jfqwTzEZ7XJ3yZ6xaZG31nUEOEyzzVImjRcsN8Wi/QyPxId/x8GTtgIbsy8kEw==}
     dev: true
@@ -7333,7 +7340,7 @@ packages:
     dependencies:
       '@types/node': 20.4.7
       cosmiconfig: 8.1.3
-      ts-node: 10.9.1(@types/node@20.4.7)(typescript@5.2.2)
+      ts-node: 10.9.1(@types/node@18.17.12)(typescript@5.2.2)
       typescript: 5.2.2
     dev: true
 
@@ -13121,38 +13128,6 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.17.12
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.2.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
-  /ts-node@10.9.1(@types/node@20.4.7)(typescript@5.2.2):
-    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.4.7
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/tools/cdk/src/stacks/docs.ts
+++ b/tools/cdk/src/stacks/docs.ts
@@ -86,7 +86,11 @@ export class DocsStack extends Stack {
     });
 
     new BucketDeployment(this, "bucket-deployment", {
-      sources: [Source.asset(path.join(path.dirname(fileURLToPath(import.meta.url)), `../build`))],
+      sources: [
+        Source.asset(
+          path.join(path.dirname(fileURLToPath(import.meta.url)), "../../../../apps/docs/build"),
+        ),
+      ],
       destinationBucket,
       distribution,
       distributionPaths: ["/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,16 @@
 {
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "strict": true,
-    "outDir": "dist",
-    "target": "ESNext",
-    "module": "ESNext",
     "declaration": true,
-    "skipLibCheck": true,
-    "noUnusedLocals": true,
     "declarationMap": true,
-    "esModuleInterop": true,
     "inlineSourceMap": true,
     "isolatedModules": true,
+    "module": "ES2022",
     "moduleResolution": "Node",
-    "resolveJsonModule": true,
     "noImplicitReturns": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "dist",
+    "resolveJsonModule": true
   },
   "include": ["*.ts", "apps/**/*", "libs/**/*", "packages/**/*", "services/**/*", "tools/**/*"],
   "exclude": [

--- a/turbo.json
+++ b/turbo.json
@@ -4,9 +4,8 @@
     "generate": {
       "cache": false
     },
-    "ant-stack#build": {},
     "build": {
-      "dependsOn": ["ant-stack#build", "^build", "^generate"],
+      "dependsOn": ["^build", "^generate"],
       "outputs": ["dist/**"]
     },
     "deploy": {


### PR DESCRIPTION
Now we're cooking :fire:

Side note: While not entirely within scope, I've taken the liberty of migrating to [@tsconfig/node18](https://www.npmjs.com/package/@tsconfig/node18) and removing some entries from the root tsconfig's compilerOptions that were already enforced by ESLint anyways.