### PR TITLE
refactor: ♻️ quick config fix

### DIFF
--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -16,6 +16,24 @@ import { App, Stack, Duration } from "aws-cdk-lib/core";
 import { config } from "dotenv";
 import type { BuildOptions } from "esbuild";
 
+/**
+ * Whether or not we're executing in CDK.
+ *
+ * During development (not in CDK) ...
+ * - Bronya is responsible for handling the development server.
+ * - The exported `main` function is imported and then called to get the CDK app.
+ * - No AWS constructs are actually allocated, since this requires certain files to be built that
+ *   may not exist during development.
+ *
+ * During deployment (in CDK) ...
+ * - The `cdk` CLI tool is responsible for deploying the CloudFormation stack.
+ * - The CLI expects the app to be created at the top level,
+ *   so the main function is also called immediately after its declaration.
+ * - All the AWS constructs are allocated, and relevant transformations are applied before
+ *   uploading the code via AWS CloudFormation.
+ */
+const executingInCdk = isCdk();
+
 config({
   path: "../../.env",
 });
@@ -135,16 +153,20 @@ function getStage() {
   if (!process.env.NODE_ENV) {
     throw new Error("NODE_ENV not set.");
   }
+
   switch (process.env.NODE_ENV) {
     case "production":
       return "prod";
+
     case "staging":
       if (!process.env.PR_NUM) {
         throw new Error("NODE_ENV was set to staging, but a PR number was not provided.");
       }
       return `staging-${process.env.PR_NUM}`;
+
     case "development":
       return "dev";
+
     default:
       throw new Error(
         "Invalid NODE_ENV specified. Valid values are 'production', 'staging', and 'development'.",
@@ -152,7 +174,11 @@ function getStage() {
   }
 }
 
-export async function main() {
+/**
+ * Bronya requires a default export or exported named `main` function that returns an {@link App}
+ * in order to support development functionality.
+ */
+export async function main(): Promise<App> {
   const id = "peterportal-api-next";
 
   const zoneName = "peterportal.org";
@@ -163,94 +189,100 @@ export async function main() {
 
   const stack = new ApiStack(app, `${id}-${stage}`, stage);
 
-  const api = stack.api;
+  await stack.api.init();
 
-  await api.init();
-
-  if (isCdk()) {
-    if (stage === "dev") {
-      throw new Error("Cannot deploy this app in the development environment.");
-    }
-
-    const result = await api.synth();
-
-    /**
-     * Add gateway responses for 5xx and 404 errors, so that they remain compliant
-     * with the {@link `ErrorResponse`} type.
-     */
-    result.api.addGatewayResponse(`${id}-${stage}-5xx`, {
-      type: ResponseType.DEFAULT_5XX,
-      statusCode: "500",
-      templates: {
-        "application/json": JSON.stringify({
-          timestamp: "$context.requestTime",
-          requestId: "$context.requestId",
-          statusCode: 500,
-          error: "Internal Server Error",
-          message: "An unknown error has occurred. Please try again.",
-        }),
-      },
-    });
-    result.api.addGatewayResponse(`${id}-${stage}-404`, {
-      type: ResponseType.MISSING_AUTHENTICATION_TOKEN,
-      statusCode: "404",
-      templates: {
-        "application/json": JSON.stringify({
-          timestamp: "$context.requestTime",
-          requestId: "$context.requestId",
-          statusCode: 404,
-          error: "Not Found",
-          message: "The requested resource could not be found.",
-        }),
-      },
-    });
-
-    /**
-     * Define the CORS response headers integration and add it to all endpoints.
-     * This is necessary since we hacked API Gateway to be able to serve binary data.
-     */
-    const corsIntegration = new LambdaIntegration(
-      new AwsLambdaFunction(result.api, `${id}-${stage}-options-handler`, {
-        code: Code.fromInline(
-          // language=JavaScript
-          'exports.h=async _=>({headers:{"Access-Control-Allow-Origin": "*","Access-Control-Allow-Headers": "Apollo-Require-Preflight,Content-Type","Access-Control-Allow-Methods": "GET,POST,OPTIONS"},statusCode:204})',
-        ),
-        handler: "index.h",
-        runtime: Runtime.NODEJS_18_X,
-        architecture: Architecture.ARM_64,
-      }),
-    );
-    result.api.methods.forEach((apiMethod) => {
-      try {
-        apiMethod.resource.addMethod("OPTIONS", corsIntegration);
-      } catch {
-        // no-op
-      }
-    });
-
-    // Set up the custom domain name and A record for the API.
-    result.api.addDomainName(`${id}-${stage}-domain`, {
-      domainName: `${stage === "prod" ? "" : `${stage}.`}api-next.peterportal.org`,
-      certificate: Certificate.fromCertificateArn(
-        result.api,
-        "peterportal-cert",
-        process.env.CERTIFICATE_ARN ?? "",
-      ),
-    });
-    new ARecord(result.api, `${id}-${stage}-a-record`, {
-      zone: HostedZone.fromHostedZoneAttributes(result.api, "peterportal-hosted-zone", {
-        zoneName,
-        hostedZoneId: process.env.HOSTED_ZONE_ID ?? "",
-      }),
-      recordName: `${stage === "prod" ? "" : `${stage}.`}api-next`,
-      target: RecordTarget.fromAlias(new ApiGateway(result.api)),
-    });
+  // In development mode, return the app so that Bronya can handle the development server.
+  // The app is not synthesized, and no AWS resources are allocated.
+  if (!executingInCdk) {
+    return app;
   }
+
+  if (stage === "dev") {
+    throw new Error("Cannot deploy this app in the development environment.");
+  }
+
+  // In deployment mode, synthesize all the AWS resources.
+  const synthesized = await stack.api.synth();
+
+  /**
+   * Add gateway responses for 5xx and 404 errors, so that they remain compliant
+   * with the {@link `ErrorResponse`} type.
+   */
+  synthesized.api.addGatewayResponse(`${id}-${stage}-5xx`, {
+    type: ResponseType.DEFAULT_5XX,
+    statusCode: "500",
+    templates: {
+      "application/json": JSON.stringify({
+        timestamp: "$context.requestTime",
+        requestId: "$context.requestId",
+        statusCode: 500,
+        error: "Internal Server Error",
+        message: "An unknown error has occurred. Please try again.",
+      }),
+    },
+  });
+
+  synthesized.api.addGatewayResponse(`${id}-${stage}-404`, {
+    type: ResponseType.MISSING_AUTHENTICATION_TOKEN,
+    statusCode: "404",
+    templates: {
+      "application/json": JSON.stringify({
+        timestamp: "$context.requestTime",
+        requestId: "$context.requestId",
+        statusCode: 404,
+        error: "Not Found",
+        message: "The requested resource could not be found.",
+      }),
+    },
+  });
+
+  /**
+   * Define the CORS response headers integration and add it to all endpoints.
+   * This is necessary since we hacked API Gateway to be able to serve binary data.
+   */
+  const corsIntegration = new LambdaIntegration(
+    new AwsLambdaFunction(synthesized.api, `${id}-${stage}-options-handler`, {
+      code: Code.fromInline(
+        // language=JavaScript
+        'exports.h=async _=>({headers:{"Access-Control-Allow-Origin": "*","Access-Control-Allow-Headers": "Apollo-Require-Preflight,Content-Type","Access-Control-Allow-Methods": "GET,POST,OPTIONS"},statusCode:204})',
+      ),
+      handler: "index.h",
+      runtime: Runtime.NODEJS_18_X,
+      architecture: Architecture.ARM_64,
+    }),
+  );
+
+  synthesized.api.methods.forEach((apiMethod) => {
+    try {
+      apiMethod.resource.addMethod("OPTIONS", corsIntegration);
+    } catch {
+      // no-op
+    }
+  });
+
+  // Set up the custom domain name and A record for the API.
+  synthesized.api.addDomainName(`${id}-${stage}-domain`, {
+    domainName: `${stage === "prod" ? "" : `${stage}.`}api-next.peterportal.org`,
+    certificate: Certificate.fromCertificateArn(
+      synthesized.api,
+      "peterportal-cert",
+      process.env.CERTIFICATE_ARN ?? "",
+    ),
+  });
+
+  new ARecord(synthesized.api, `${id}-${stage}-a-record`, {
+    zone: HostedZone.fromHostedZoneAttributes(synthesized.api, "peterportal-hosted-zone", {
+      zoneName,
+      hostedZoneId: process.env.HOSTED_ZONE_ID ?? "",
+    }),
+    recordName: `${stage === "prod" ? "" : `${stage}.`}api-next`,
+    target: RecordTarget.fromAlias(new ApiGateway(synthesized.api)),
+  });
 
   return app;
 }
 
-if (isCdk()) {
+if (executingInCdk) {
   // Sike, looks like even though we have top-level await, the dev server won't start with it :(
   main().then();
 }

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -158,20 +158,16 @@ function getStage() {
   if (!process.env.NODE_ENV) {
     throw new Error("NODE_ENV not set.");
   }
-
   switch (process.env.NODE_ENV) {
     case "production":
       return "prod";
-
     case "staging":
       if (!process.env.PR_NUM) {
         throw new Error("NODE_ENV was set to staging, but a PR number was not provided.");
       }
       return `staging-${process.env.PR_NUM}`;
-
     case "development":
       return "dev";
-
     default:
       throw new Error(
         "Invalid NODE_ENV specified. Valid values are 'production', 'staging', and 'development'.",

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -1,7 +1,7 @@
 import { chmodSync, copyFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-import { Api, ApiConstructProps } from "@bronya.js/api-construct";
+import { Api, type ApiConstructProps } from "@bronya.js/api-construct";
 import { createApiCliPlugins } from "@bronya.js/api-construct/plugins/cli";
 import { isCdk } from "@bronya.js/core";
 import { logger } from "@libs/lambda";

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -17,10 +17,10 @@ import { config } from "dotenv";
 import type { BuildOptions } from "esbuild";
 
 /**
- * Whether or not we're executing in CDK.
+ * Whether we're executing in CDK.
  *
  * During development (not in CDK) ...
- * - Bronya is responsible for handling the development server.
+ * - Bronya.js is responsible for handling the development server.
  * - The exported `main` function is imported and then called to get the CDK app.
  * - No AWS constructs are actually allocated, since this requires certain files to be built that
  *   may not exist during development.
@@ -98,7 +98,7 @@ export const esbuildOptions: BuildOptions = {
 
   /**
    * @remarks
-   * For Fourmilier: this is specified in order to guarantee that the file is interprested as ESM.
+   * For Bronya.js: this is specified in order to guarantee that the file is interpreted as ESM.
    * However, the framework will continue to assume `handler.js` is the entrypoint.
    *
    * @RFC What would be the best way to resolve these two values?
@@ -160,7 +160,7 @@ class ApiStack extends Stack {
 
       /**
        * @remarks
-       * For Fourmilier: although ESBuild specified that "js" -> "mjs", the framework
+       * For Bronya.js: although ESBuild specified that "js" -> "mjs", the framework
        * still assumes that the entrypoint is `handler.js` unless explicitly specified.
        */
       exitPoint: "handler.mjs",

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -1,9 +1,4 @@
-import { readdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
-
 import { ApiPropsOverride } from "@bronya.js/api-construct";
-import { Rule, RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
-import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import {
   Effect,
   ManagedPolicy,
@@ -12,9 +7,8 @@ import {
   Role,
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
-import { Duration } from "aws-cdk-lib/core";
 
-import { esbuildOptions } from "../../../../../bronya.config";
+import { esbuildOptions, constructs } from "../../../../../bronya.config";
 
 export const overrides: ApiPropsOverride = {
   constructs: {
@@ -39,31 +33,7 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin: ({ functionProps, handler }, scope) => {
-      const warmingTarget = new LambdaFunction(handler, {
-        event: RuleTargetInput.fromObject({ body: "warming request" }),
-      });
-
-      const warmingRule = new Rule(scope, `${functionProps.functionName}-warming-rule`, {
-        schedule: Schedule.rate(Duration.minutes(5)),
-      });
-
-      warmingRule.addTarget(warmingTarget);
-    },
-    lambdaUpload: (directory) => {
-      const queryEngines = readdirSync(directory).filter((x) => x.endsWith(".so.node"));
-
-      if (queryEngines.length === 1) {
-        return;
-      }
-
-      queryEngines
-        .filter((x) => x !== "libquery_engine-linux-arm64-openssl-1.0.x.so.node")
-        .forEach((queryEngineFile) => {
-          rmSync(join(directory, queryEngineFile));
-        });
-    },
-    restApiProps: () => ({ disableExecuteApiEndpoint: true, binaryMediaTypes: ["*/*"] }),
+    ...constructs,
   },
   esbuild: {
     ...esbuildOptions,

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -8,7 +8,7 @@ import {
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
 
-import { esbuildOptions, constructs } from "../../../../../bronya.config";
+import { constructs, esbuildOptions } from "../../../../../bronya.config";
 
 export const overrides: ApiPropsOverride = {
   constructs: {

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -1,9 +1,4 @@
-import { readdirSync, rmSync } from "node:fs";
-import { join } from "node:path";
-
 import { ApiPropsOverride } from "@bronya.js/api-construct";
-import { Rule, RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
-import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import {
   Effect,
   ManagedPolicy,
@@ -12,9 +7,8 @@ import {
   Role,
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
-import { Duration } from "aws-cdk-lib/core";
 
-import { esbuildOptions } from "../../../../../../bronya.config";
+import { constructs, esbuildOptions } from "../../../../../../bronya.config";
 
 export const overrides: ApiPropsOverride = {
   constructs: {
@@ -39,31 +33,7 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    functionPlugin: ({ functionProps, handler }, scope) => {
-      const warmingTarget = new LambdaFunction(handler, {
-        event: RuleTargetInput.fromObject({ body: "warming request" }),
-      });
-
-      const warmingRule = new Rule(scope, `${functionProps.functionName}-warming-rule`, {
-        schedule: Schedule.rate(Duration.minutes(5)),
-      });
-
-      warmingRule.addTarget(warmingTarget);
-    },
-    lambdaUpload: (directory) => {
-      const queryEngines = readdirSync(directory).filter((x) => x.endsWith(".so.node"));
-
-      if (queryEngines.length === 1) {
-        return;
-      }
-
-      queryEngines
-        .filter((x) => x !== "libquery_engine-linux-arm64-openssl-1.0.x.so.node")
-        .forEach((queryEngineFile) => {
-          rmSync(join(directory, queryEngineFile));
-        });
-    },
-    restApiProps: () => ({ disableExecuteApiEndpoint: true, binaryMediaTypes: ["*/*"] }),
+    ...constructs,
   },
   esbuild: {
     ...esbuildOptions,


### PR DESCRIPTION
# Summary
- I have my env at the project root, so I'd like `dotenv` to just load that one for me when I happen to be in the `apps/api` directory
- Ideally, the built routes in the temporary `.bronya` directory don't actually need to include prisma because the dev server can find prisma just fine since it defaults to `node_modules` which exists locally. This speeds up the dev build because we don't have to manipulate any files before starting up. Also, I encountered some issues with "binary for ARM64" not found, which seemed to be mitigated when no copying takes place (because `node_modules` is a more reliable place to find prisma)

# Followup
- I think it would definitely be nice if the config file supported top-level await. Since I got tired of maintaining my custom JIT compiler, I switched back to JITI -- which actually happens [working on this feature](https://github.com/unjs/jiti/issues/72#issuecomment-1713502405)  :eyes: