### PR TITLE
feat: ✨ create handler helper function

### DIFF
--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -86,7 +86,7 @@ export const esbuildOptions: BuildOptions = {
   format: "esm",
   platform: "node",
   bundle: true,
-  minify: true,
+  // minify: true,
   banner: { js },
 
   /**

--- a/apps/api/bronya.config.ts
+++ b/apps/api/bronya.config.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 import { Api, type ApiConstructProps } from "@bronya.js/api-construct";
 import { createApiCliPlugins } from "@bronya.js/api-construct/plugins/cli";
 import { isCdk } from "@bronya.js/core";
-import { logger } from "@libs/lambda";
+import { logger, warmingRequestBody } from "@libs/lambda";
 import { LambdaIntegration, ResponseType } from "aws-cdk-lib/aws-apigateway";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { RuleTargetInput, Rule, Schedule } from "aws-cdk-lib/aws-events";
@@ -78,13 +78,6 @@ const prismaSchema = resolve(libsDbDirectory, "prisma", prismaSchemaFile);
  * Name of the Prisma query engine file that's used on AWS Lambda.
  */
 const prismaQueryEngineFile = "libquery_engine-linux-arm64-openssl-1.0.x.so.node";
-
-/**
- * The body of a warming request.
- *
- * TODO: actually recognize warming requests in the route handlers.
- */
-const warmingRequestBody = { body: "warming request" };
 
 /**
  * Shared ESBuild options.

--- a/apps/api/src/routes/v1/graphql/+config.ts
+++ b/apps/api/src/routes/v1/graphql/+config.ts
@@ -3,7 +3,7 @@ import { join, resolve } from "node:path";
 
 import { ApiPropsOverride } from "@bronya.js/api-construct";
 
-import { esbuildOptions } from "../../../../bronya.config";
+import { esbuildOptions, constructs } from "../../../../bronya.config";
 
 export const overrides: ApiPropsOverride = {
   esbuild: {
@@ -26,5 +26,9 @@ export const overrides: ApiPropsOverride = {
         },
       },
     ],
+  },
+  constructs: {
+    functionPlugin: constructs.functionPlugin,
+    restApiProps: constructs.restApiProps,
   },
 };

--- a/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
@@ -1,31 +1,18 @@
 import { PrismaClient } from "@libs/db";
 import { createOKResult, createErrorResult } from "@libs/lambda";
+import { createHandler } from "@libs/lambda";
 import { getTermDateData } from "@libs/uc-irvine-api/registrar";
 import type { Quarter, QuarterDates } from "@peterportal-api/types";
-import type { APIGatewayProxyHandler } from "aws-lambda";
 import { ZodError } from "zod";
 
 import { QuerySchema } from "./schema";
 
 const prisma = new PrismaClient();
 
-export const GET: APIGatewayProxyHandler = async (event, context) => {
+export const GET = createHandler(async (event, context) => {
   const headers = event.headers;
   const query = event.queryStringParameters;
   const requestId = context.awsRequestId;
-
-  /**
-   * TODO: handle warmer requests.
-   */
-
-  // if (request.isWarmerRequest) {
-  //   try {
-  //     await prisma.$connect();
-  //     return createOKResult("Warmed", headers, requestId);
-  //   } catch (e) {
-  //     createErrorResult(500, e, requestId);
-  //   }
-  // }
 
   try {
     const where = QuerySchema.parse(query);
@@ -72,4 +59,4 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
     }
     return createErrorResult(400, error, requestId);
   }
-};
+});

--- a/apps/api/src/routes/v1/rest/courses/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/courses/+endpoint.ts
@@ -18,6 +18,7 @@ export const GET = createHandler(async (event, context, res) => {
 
   try {
     const parsedQuery = QuerySchema.parse(query);
+
     // The query object being empty shouldn't return all courses, since there's /courses/all for that.
     if (!Object.keys(parsedQuery).length) {
       return res.createErrorResult(400, "Course number not provided", requestId);

--- a/apps/api/src/routes/v1/rest/courses/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/courses/+endpoint.ts
@@ -11,7 +11,7 @@ async function onWarm() {
   await prisma.$connect();
 }
 
-export const get = createHandler(async (event, context, res) => {
+export const GET = createHandler(async (event, context, res) => {
   const headers = event.headers;
   const query = event.queryStringParameters;
   const requestId = context.awsRequestId;

--- a/apps/api/src/routes/v1/rest/courses/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/courses/+endpoint.ts
@@ -1,6 +1,5 @@
 import { PrismaClient } from "@libs/db";
-import { createErrorResult, createOKResult } from "@libs/lambda";
-import type { APIGatewayProxyHandler } from "aws-lambda";
+import { createHandler } from "@libs/lambda";
 import { ZodError } from "zod";
 
 import { constructPrismaQuery, normalizeCourse } from "./lib";
@@ -8,39 +7,30 @@ import { QuerySchema } from "./schema";
 
 const prisma = new PrismaClient();
 
-export const GET: APIGatewayProxyHandler = async (event, context) => {
+async function onWarm() {
+  await prisma.$connect();
+}
+
+export const get = createHandler(async (event, context, res) => {
   const headers = event.headers;
   const query = event.queryStringParameters;
   const requestId = context.awsRequestId;
-
-  /**
-   * TODO: handle warmer requests.
-   */
-
-  // if (request.isWarmerRequest) {
-  //   try {
-  //     await prisma.$connect();
-  //     return createOKResult("Warmed", headers, requestId);
-  //   } catch (e) {
-  //     createErrorResult(500, e, requestId);
-  //   }
-  // }
 
   try {
     const parsedQuery = QuerySchema.parse(query);
     // The query object being empty shouldn't return all courses, since there's /courses/all for that.
     if (!Object.keys(parsedQuery).length) {
-      return createErrorResult(400, "Course number not provided", requestId);
+      return res.createErrorResult(400, "Course number not provided", requestId);
     }
 
     const courses = await prisma.course.findMany({ where: constructPrismaQuery(parsedQuery) });
 
-    return createOKResult(courses.map(normalizeCourse), headers, requestId);
+    return res.createOKResult(courses.map(normalizeCourse), headers, requestId);
   } catch (error) {
     if (error instanceof ZodError) {
       const messages = error.issues.map((issue) => issue.message);
-      return createErrorResult(400, messages.join("; "), requestId);
+      return res.createErrorResult(400, messages.join("; "), requestId);
     }
-    return createErrorResult(400, error, requestId);
+    return res.createErrorResult(400, error, requestId);
   }
-};
+}, onWarm);

--- a/apps/api/src/routes/v1/rest/courses/{id}/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/courses/{id}/+endpoint.ts
@@ -9,7 +9,7 @@ async function onWarm() {
   await prisma.$connect();
 }
 
-export const get = createHandler(async (event, context, res) => {
+export const GET = createHandler(async (event, context, res) => {
   const headers = event.headers;
   const requestId = context.awsRequestId;
   const params = event.pathParameters;

--- a/apps/api/src/routes/v1/rest/courses/{id}/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/courses/{id}/+endpoint.ts
@@ -1,40 +1,30 @@
 import { PrismaClient } from "@libs/db";
-import { createErrorResult, createOKResult } from "@libs/lambda";
-import type { APIGatewayProxyHandler } from "aws-lambda";
+import { createHandler } from "@libs/lambda";
 
 import { normalizeCourse } from "../lib";
 
 const prisma = new PrismaClient();
 
-export const GET: APIGatewayProxyHandler = async (event, context) => {
+async function onWarm() {
+  await prisma.$connect();
+}
+
+export const get = createHandler(async (event, context, res) => {
   const headers = event.headers;
   const requestId = context.awsRequestId;
   const params = event.pathParameters;
 
-  /**
-   * TODO: handle warmer requests.
-   */
-
-  // if (request.isWarmerRequest) {
-  //   try {
-  //     await prisma.$connect();
-  //     return createOKResult("Warmed", headers, requestId);
-  //   } catch (e) {
-  //     createErrorResult(500, e, requestId);
-  //   }
-  // }
-
   if (params?.id == null) {
-    return createErrorResult(400, "Course number not provided", requestId);
+    return res.createErrorResult(400, "Course number not provided", requestId);
   }
 
   if (params?.id === "all") {
     const courses = await prisma.course.findMany();
-    return createOKResult(courses.map(normalizeCourse), headers, requestId);
+    return res.createOKResult(courses.map(normalizeCourse), headers, requestId);
   }
 
   try {
-    return createOKResult(
+    return res.createOKResult(
       normalizeCourse(
         await prisma.course.findFirstOrThrow({
           where: { id: decodeURIComponent(params.id) },
@@ -44,6 +34,6 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
       requestId,
     );
   } catch {
-    return createErrorResult(404, `Course ${params.id} not found`, requestId);
+    return res.createErrorResult(404, `Course ${params.id} not found`, requestId);
   }
-};
+}, onWarm);

--- a/apps/api/src/routes/v1/rest/instructors/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/instructors/+endpoint.ts
@@ -1,6 +1,5 @@
 import { PrismaClient } from "@libs/db";
-import { createErrorResult, createOKResult } from "@libs/lambda";
-import type { APIGatewayProxyHandler } from "aws-lambda";
+import { createHandler } from "@libs/lambda";
 import { ZodError } from "zod";
 
 import { constructPrismaQuery } from "./lib";
@@ -8,35 +7,26 @@ import { QuerySchema } from "./schema";
 
 const prisma = new PrismaClient();
 
-export const GET: APIGatewayProxyHandler = async (event, context) => {
+async function onWarm() {
+  await prisma.$connect();
+}
+
+export const GET = createHandler(async (event, context, res) => {
   const headers = event.headers;
   const query = event.queryStringParameters;
   const requestId = context.awsRequestId;
-
-  /**
-   * TODO: handle warmer requests.
-   */
-
-  // if (request.isWarmerRequest) {
-  //   try {
-  //     await prisma.$connect();
-  //     return createOKResult("Warmed", headers, requestId);
-  //   } catch (e) {
-  //     createErrorResult(500, e, requestId);
-  //   }
-  // }
 
   try {
     const parsedQuery = QuerySchema.parse(query);
     // The query object being empty shouldn't return all courses, since there's /courses/all for that.
     if (!Object.keys(parsedQuery).length)
-      return createErrorResult(400, "Instructor UCInetID not provided", requestId);
+      return res.createErrorResult(400, "Instructor UCInetID not provided", requestId);
     const instructors = await prisma.instructor.findMany({
       where: constructPrismaQuery(parsedQuery),
     });
     if (parsedQuery.taughtInTerms) {
       const terms = new Set(parsedQuery.taughtInTerms);
-      return createOKResult(
+      return res.createOKResult(
         instructors.filter(
           (instructor) =>
             [...new Set(Object.values(instructor.courseHistory as Record<string, string[]>))]
@@ -47,12 +37,12 @@ export const GET: APIGatewayProxyHandler = async (event, context) => {
         requestId,
       );
     }
-    return createOKResult(instructors, headers, requestId);
+    return res.createOKResult(instructors, headers, requestId);
   } catch (error) {
     if (error instanceof ZodError) {
       const messages = error.issues.map((issue) => issue.message);
-      return createErrorResult(400, messages.join("; "), requestId);
+      return res.createErrorResult(400, messages.join("; "), requestId);
     }
-    return createErrorResult(400, error, requestId);
+    return res.createErrorResult(400, error, requestId);
   }
-};
+}, onWarm);

--- a/libs/lambda/src/handler.ts
+++ b/libs/lambda/src/handler.ts
@@ -1,0 +1,30 @@
+import type { APIGatewayProxyEvent, Context, APIGatewayProxyResult } from "aws-lambda";
+
+import { warmingRequestBody } from "./request";
+import { createOKResult, createErrorResult } from "./response";
+
+export type ResponseHelpers = {
+  ok: typeof createOKResult;
+  error: typeof createErrorResult;
+};
+
+export type ExtendedApiGatewayHandler = (
+  event: APIGatewayProxyEvent,
+  context: Context,
+  res: ResponseHelpers,
+) => APIGatewayProxyResult | Promise<APIGatewayProxyResult>;
+
+export function createHandler(handler: ExtendedApiGatewayHandler): ExtendedApiGatewayHandler {
+  return async function (event, context) {
+    const res: ResponseHelpers = {
+      ok: (payload, headers, requestId) => createOKResult(payload, headers, requestId),
+      error: (statusCode, e, requestId) => createErrorResult(statusCode, e, requestId),
+    };
+
+    if (event.body === JSON.stringify(warmingRequestBody)) {
+      return res.ok("Successfully warmed!", event.headers, context.awsRequestId);
+    }
+
+    return handler(event, context, res);
+  };
+}

--- a/libs/lambda/src/handler.ts
+++ b/libs/lambda/src/handler.ts
@@ -1,29 +1,73 @@
-import type { APIGatewayProxyEvent, Context, APIGatewayProxyResult } from "aws-lambda";
+import type { APIGatewayProxyEvent, Callback, Context, APIGatewayProxyResult } from "aws-lambda";
 
 import { warmingRequestBody } from "./request";
 import { createOKResult, createErrorResult } from "./response";
 
+/**
+ * `res` object like Express.js .
+ */
 export type ResponseHelpers = {
-  ok: typeof createOKResult;
-  error: typeof createErrorResult;
+  /**
+   * Create an OK response.
+   */
+  createOKResult: typeof createOKResult;
+
+  /**
+   * Create an error response.
+   */
+  createErrorResult: typeof createErrorResult;
+
+  /**
+   * Create an ok response and send it.
+   */
+  ok: <T>(
+    payload: T,
+    requestHeaders: Record<string, string | undefined>,
+    requestId: string,
+  ) => void;
+
+  /**
+   * Create an error response and send it.
+   */
+  error: (statusCode: number, e: unknown, requestId: string) => void;
 };
 
 export type ExtendedApiGatewayHandler = (
   event: APIGatewayProxyEvent,
   context: Context,
   res: ResponseHelpers,
-) => APIGatewayProxyResult | Promise<APIGatewayProxyResult>;
+) => void | APIGatewayProxyResult | Promise<APIGatewayProxyResult | void>;
 
-export function createHandler(handler: ExtendedApiGatewayHandler): ExtendedApiGatewayHandler {
-  return async function (event, context) {
-    const res: ResponseHelpers = {
-      ok: (payload, headers, requestId) => createOKResult(payload, headers, requestId),
-      error: (statusCode, e, requestId) => createErrorResult(statusCode, e, requestId),
-    };
+/**
+ * Override the type from aws-lambda because it's bad.
+ */
+export type APIGatewayProxyHandler = (
+  event: APIGatewayProxyEvent,
+  context: Context,
+  callback: Callback<APIGatewayProxyResult>,
+) => void | Promise<APIGatewayProxyResult | void>;
 
+/**
+ * Creates a handler for API Gateway.
+ *
+ * Handles warming requests and provides utilities for formatting responses.
+ */
+export function createHandler(handler: ExtendedApiGatewayHandler): APIGatewayProxyHandler {
+  return async function (event, context, callback) {
     if (event.body === JSON.stringify(warmingRequestBody)) {
-      return res.ok("Successfully warmed!", event.headers, context.awsRequestId);
+      return createOKResult("Successfully warmed!", event.headers, context.awsRequestId);
     }
+
+    const res: ResponseHelpers = {
+      ok: (payload, headers, requestId) => {
+        callback(undefined, createOKResult(payload, headers, requestId));
+      },
+      error: (statusCode, e, requestId) => {
+        callback(undefined, createErrorResult(statusCode, e, requestId));
+      },
+      createOKResult,
+      createErrorResult,
+    };
 
     return handler(event, context, res);
   };

--- a/libs/lambda/src/index.ts
+++ b/libs/lambda/src/index.ts
@@ -2,3 +2,5 @@ export * from "./logger";
 export * from "./compress";
 export * from "./response";
 export * from "./constants";
+export * from "./request";
+export * from "./handler";

--- a/libs/lambda/src/request.ts
+++ b/libs/lambda/src/request.ts
@@ -1,0 +1,7 @@
+/**
+ * The body of a warming request.
+ *
+ * A warming request is periodically sent to ensure that the Lambda function is active.
+ * Ideally, it wouldn't trigger any expensive computations.
+ */
+export const warmingRequestBody = { body: "warming request" };


### PR DESCRIPTION
# Summary
- Add a `createHandler` function to the internal `@libs/lambda` package for API developers to use when creating new endpoints. 
- The function will check whether or not it's a warming request prior to executing the handler itself.

# Technical Details
- This function accepts a callback with the typical `event` and `context` parameters from API Gateway, along with a utility `res` object (similar to the one in Express.js) to generate a proper response object.
- The CDK framework doesn't handle warming requests out of the box, but we add them to the CDK after the relevant API Gateway resources are allocated. Then we handle the warming requests with a custom, internal handler wrapper.