### PR TITLE
fix(api): 🐛 merge construct props and function props correctly

### DIFF
--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -12,7 +12,9 @@ import { constructs, esbuildOptions } from "../../../../../bronya.config";
 
 export const overrides: ApiPropsOverride = {
   constructs: {
+    ...constructs,
     functionProps: (scope, id) => ({
+      ...constructs.functionProps(scope, id),
       role: new Role(scope, `${id}-v1-rest-websoc-role`, {
         assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
         managedPolicies: [
@@ -33,7 +35,6 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    ...constructs,
   },
   esbuild: {
     ...esbuildOptions,

--- a/apps/api/src/routes/v1/rest/websoc/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/+config.ts
@@ -14,7 +14,7 @@ export const overrides: ApiPropsOverride = {
   constructs: {
     ...constructs,
     functionProps: (scope, id) => ({
-      ...constructs.functionProps(scope, id),
+      ...constructs.functionProps?.(scope, id),
       role: new Role(scope, `${id}-v1-rest-websoc-role`, {
         assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
         managedPolicies: [

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -14,7 +14,7 @@ export const overrides: ApiPropsOverride = {
   constructs: {
     ...constructs,
     functionProps: (scope, id) => ({
-      ...constructs.functionProps(scope, id),
+      ...constructs.functionProps?.(scope, id),
       role: new Role(scope, `${id}-v1-rest-websoc-id-role`, {
         assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
         managedPolicies: [

--- a/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
+++ b/apps/api/src/routes/v1/rest/websoc/{id}/+config.ts
@@ -12,7 +12,9 @@ import { constructs, esbuildOptions } from "../../../../../../bronya.config";
 
 export const overrides: ApiPropsOverride = {
   constructs: {
+    ...constructs,
     functionProps: (scope, id) => ({
+      ...constructs.functionProps(scope, id),
       role: new Role(scope, `${id}-v1-rest-websoc-id-role`, {
         assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
         managedPolicies: [
@@ -33,7 +35,6 @@ export const overrides: ApiPropsOverride = {
         },
       }),
     }),
-    ...constructs,
   },
   esbuild: {
     ...esbuildOptions,


### PR DESCRIPTION
# Summary
Re-order the config merging.

# Details
The root function props were overriding the route-specific ones, which is problematic for the websoc routes because they lost the `role` property. 

I've monkey-patched production for now by adding a permission policy to the IAM role for the `/v1/rest/websoc` route.
![image](https://github.com/icssc/peterportal-api-next/assets/66761366/ca35a788-9a05-4d29-8542-2c4f219b49c0)
