### PR TITLE
feat: ✨ add calendar scraper and dump endpoint

### DIFF
--- a/apps/api/src/routes/v1/graphql/resolvers.ts
+++ b/apps/api/src/routes/v1/graphql/resolvers.ts
@@ -4,6 +4,7 @@ import { geTransform, proxyRestApi } from "./lib";
 
 export const resolvers: ApolloServerOptions<BaseContext>["resolvers"] = {
   Query: {
+    allTermDates: proxyRestApi("/v1/rest/calendar"),
     calendar: proxyRestApi("/v1/rest/calendar"),
     course: proxyRestApi("/v1/rest/courses", { pathArg: "courseId" }),
     courses: proxyRestApi("/v1/rest/courses", { argsTransform: geTransform }),

--- a/apps/api/src/routes/v1/graphql/schema/calendar.graphql
+++ b/apps/api/src/routes/v1/graphql/schema/calendar.graphql
@@ -1,16 +1,24 @@
 "An object that includes important dates for a specified quarter."
-type QuarterDates {
-  "When instruction begins for the given quarter."
+type TermDates {
+  "The year of the given term."
+  year: String!
+  "The quarter of the given term."
+  quarter: String!
+  "When instruction begins for the given term."
   instructionStart: Date!
-  "When instruction ends for the given quarter."
+  "When instruction ends for the given term."
   instructionEnd: Date!
-  "When finals begin for the given quarter."
+  "When finals begin for the given term."
   finalsStart: Date!
-  "When finals end for the given quarter."
+  "When finals end for the given term."
   finalsEnd: Date!
+  "When the Schedule of Classes becomes available for the given term."
+  socAvailable: Date!
 }
 
 extend type Query {
-  "Get important dates for a quarter."
-  calendar(year: String!, quarter: Quarter!): QuarterDates!
+  "Get all available terms and their important dates."
+  allTermDates: [TermDates!]!
+  "Get important dates for a term."
+  calendar(year: String!, quarter: Quarter!): TermDates!
 }

--- a/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
@@ -34,6 +34,7 @@ export const GET = createHandler(async (event, context, res) => {
         instructionEnd: true,
         finalsStart: true,
         finalsEnd: true,
+        socAvailable: true,
       },
     });
     return result

--- a/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
@@ -27,16 +27,7 @@ export const GET = createHandler(async (event, context, res) => {
   const { data: where } = maybeParsed;
 
   if ("year" in where) {
-    const result = await prisma.calendarTerm.findFirst({
-      where,
-      select: {
-        instructionStart: true,
-        instructionEnd: true,
-        finalsStart: true,
-        finalsEnd: true,
-        socAvailable: true,
-      },
-    });
+    const result = await prisma.calendarTerm.findFirst({ where });
     return result
       ? res.createOKResult<QuarterDates>(result, headers, requestId)
       : res.createErrorResult(

--- a/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/calendar/+endpoint.ts
@@ -1,8 +1,6 @@
 import { PrismaClient } from "@libs/db";
 import { createHandler } from "@libs/lambda";
-import { getTermDateData } from "@libs/uc-irvine-lib/registrar";
-import type { Quarter, QuarterDates } from "@peterportal-api/types";
-import { ZodError } from "zod";
+import type { QuarterDates } from "@peterportal-api/types";
 
 import { QuerySchema } from "./schema";
 
@@ -14,12 +12,21 @@ async function onWarm() {
 
 export const GET = createHandler(async (event, context, res) => {
   const headers = event.headers;
-  const query = event.queryStringParameters;
+  const query = event.queryStringParameters ?? {};
   const requestId = context.awsRequestId;
 
-  try {
-    const where = QuerySchema.parse(query);
+  const maybeParsed = QuerySchema.safeParse(query);
 
+  if (!maybeParsed.success)
+    return res.createErrorResult(
+      400,
+      maybeParsed.error.issues.map((issue) => issue.message).join("; "),
+      requestId,
+    );
+
+  const { data: where } = maybeParsed;
+
+  if ("year" in where) {
     const result = await prisma.calendarTerm.findFirst({
       where,
       select: {
@@ -29,41 +36,17 @@ export const GET = createHandler(async (event, context, res) => {
         finalsEnd: true,
       },
     });
-
-    if (result) {
-      return res.createOKResult<QuarterDates>(result, headers, requestId);
-    }
-
-    const termDateData = await getTermDateData(
-      where.quarter === "Fall" ? where.year : (parseInt(where.year) - 1).toString(10),
-    );
-
-    await prisma.calendarTerm.createMany({
-      data: Object.entries(termDateData).map(([term, data]) => ({
-        year: term.split(" ")[0],
-        quarter: term.split(" ")[1] as Quarter,
-        ...data,
-      })),
-    });
-
-    if (!Object.keys(termDateData).length) {
-      return res.createErrorResult(
-        400,
-        `The requested term, ${where.year} ${where.quarter}, is currently unavailable.`,
-        requestId,
-      );
-    }
-
-    return res.createOKResult(
-      termDateData[[where.year, where.quarter].join(" ")],
-      headers,
-      requestId,
-    );
-  } catch (error) {
-    if (error instanceof ZodError) {
-      const messages = error.issues.map((issue) => issue.message);
-      return res.createErrorResult(400, messages.join("; "), requestId);
-    }
-    return res.createErrorResult(400, error, requestId);
+    return result
+      ? res.createOKResult<QuarterDates>(result, headers, requestId)
+      : res.createErrorResult(
+          400,
+          `The requested term, ${where.year} ${where.quarter}, is currently unavailable.`,
+          requestId,
+        );
   }
+  return res.createOKResult(
+    await prisma.calendarTerm.findMany({ orderBy: { instructionStart: "asc" } }),
+    headers,
+    requestId,
+  );
 }, onWarm);

--- a/apps/api/src/routes/v1/rest/calendar/schema.ts
+++ b/apps/api/src/routes/v1/rest/calendar/schema.ts
@@ -1,15 +1,17 @@
 import { quarters } from "@peterportal-api/types";
 import { z } from "zod";
 
-export const QuerySchema = z.object({
-  year: z
-    .string({ required_error: 'Parameter "year" not provided' })
-    .length(4, { message: "Invalid year provided" }),
+export const QuerySchema = z
+  .object({
+    year: z
+      .string({ required_error: 'Parameter "year" not provided' })
+      .length(4, { message: "Invalid year provided" }),
 
-  quarter: z.enum(quarters, {
-    required_error: 'Parameter "quarter" not provided',
-    invalid_type_error: "Invalid quarter provided",
-  }),
-});
+    quarter: z.enum(quarters, {
+      required_error: 'Parameter "quarter" not provided',
+      invalid_type_error: "Invalid quarter provided",
+    }),
+  })
+  .or(z.object({}));
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/libs/db/prisma/schema.prisma
+++ b/libs/db/prisma/schema.prisma
@@ -49,10 +49,11 @@ enum WebsocSectionType {
 model CalendarTerm {
   year             String
   quarter          Quarter
-  instructionStart DateTime
-  instructionEnd   DateTime
-  finalsStart      DateTime
-  finalsEnd        DateTime
+  instructionStart DateTime @db.Date
+  instructionEnd   DateTime @db.Date
+  finalsStart      DateTime @db.Date
+  finalsEnd        DateTime @db.Date
+  socAvailable     DateTime @default("1970-01-01T00:00:00Z") @db.Date
 
   @@id([year, quarter])
   @@unique([year, quarter], name: "idx")

--- a/libs/uc-irvine-lib/src/registrar/index.ts
+++ b/libs/uc-irvine-lib/src/registrar/index.ts
@@ -5,6 +5,10 @@ import fetch from "cross-fetch";
 
 const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
+const terms = ["Fall", "Winter", "Spring"];
+
+const summerTerms = ["Summer1", "Summer10wk", "Summer2"];
+
 function addSingleDateRow(
   data: string[][],
   index: number,
@@ -177,6 +181,29 @@ export async function getTermDateData(year: string): Promise<Record<string, Quar
           ((ret[key] as QuarterDates).instructionStart.getDay() - 1),
       );
     }
+  }
+
+  const socAvailable = $table
+    .eq(0)
+    .find("tr")
+    .text()
+    .split("\n")
+    .map((x) => x.trim())
+    .filter((x) => x.length)
+    .slice(4, 7);
+
+  for (const key in terms) {
+    const yr = Number.parseInt(year) + Number(terms[key] !== "Fall");
+    (ret[`${yr} ${terms[key]}`] as QuarterDates).socAvailable = new Date(
+      yr - Number(terms[key] === "Winter"),
+      months.indexOf(socAvailable[key].split(" ")[0]),
+      Number.parseInt(socAvailable[key].split(" ")[1]),
+    );
+  }
+
+  for (const term of summerTerms) {
+    const yr = Number.parseInt(year) + 1;
+    (ret[`${yr} ${term}`] as QuarterDates).socAvailable = new Date(`${yr}-03-01`);
   }
 
   return ret as Record<string, QuarterDates>;

--- a/libs/uc-irvine-lib/src/registrar/index.ts
+++ b/libs/uc-irvine-lib/src/registrar/index.ts
@@ -9,11 +9,13 @@ const terms = ["Fall", "Winter", "Spring"];
 
 const summerTerms = ["Summer1", "Summer10wk", "Summer2"];
 
+type ScrapedQuarterDates = Omit<QuarterDates, "year" | "quarter">;
+
 function addSingleDateRow(
   data: string[][],
   index: number,
   key: string,
-  record: Record<string, Partial<QuarterDates & { [p: string]: Date }>>,
+  record: Record<string, Partial<ScrapedQuarterDates & { [p: string]: Date }>>,
   year: string,
   offset = 0,
 ): void {
@@ -33,7 +35,7 @@ function addMultipleDateRow(
   index: number,
   keyStart: string,
   keyEnd: string,
-  record: Record<string, Partial<QuarterDates & { [p: string]: Date }>>,
+  record: Record<string, Partial<ScrapedQuarterDates & { [p: string]: Date }>>,
   year: string,
   offset = 0,
 ): void {
@@ -74,7 +76,7 @@ function addMultipleDateRow(
 /**
  * Returns relevant date data for each term in the given academic year.
  */
-export async function getTermDateData(year: string): Promise<Record<string, QuarterDates>> {
+export async function getTermDateData(year: string): Promise<Record<string, ScrapedQuarterDates>> {
   if (year.length !== 4 || isNaN(parseInt(year))) {
     throw new Error("Error: Invalid year provided.");
   }
@@ -134,7 +136,7 @@ export async function getTermDateData(year: string): Promise<Record<string, Quar
         p[c] = {};
         return p;
       },
-      {} as Record<string, Partial<QuarterDates>>,
+      {} as Record<string, Partial<ScrapedQuarterDates>>,
     );
 
   addSingleDateRow(quarterData, 2, "instructionStart", ret, year);
@@ -171,14 +173,14 @@ export async function getTermDateData(year: string): Promise<Record<string, Quar
   // Normalize all terms to start on a Monday, or a Thursday if it is Fall.
   for (const key in ret) {
     if (key.includes("Fall")) {
-      (ret[key] as QuarterDates).instructionStart.setDate(
-        (ret[key] as QuarterDates).instructionStart.getDate() -
-          ((ret[key] as QuarterDates).instructionStart.getDay() - 4),
+      (ret[key] as ScrapedQuarterDates).instructionStart.setDate(
+        (ret[key] as ScrapedQuarterDates).instructionStart.getDate() -
+          ((ret[key] as ScrapedQuarterDates).instructionStart.getDay() - 4),
       );
     } else {
-      (ret[key] as QuarterDates).instructionStart.setDate(
-        (ret[key] as QuarterDates).instructionStart.getDate() -
-          ((ret[key] as QuarterDates).instructionStart.getDay() - 1),
+      (ret[key] as ScrapedQuarterDates).instructionStart.setDate(
+        (ret[key] as ScrapedQuarterDates).instructionStart.getDate() -
+          ((ret[key] as ScrapedQuarterDates).instructionStart.getDay() - 1),
       );
     }
   }
@@ -194,7 +196,7 @@ export async function getTermDateData(year: string): Promise<Record<string, Quar
 
   for (const key in terms) {
     const yr = Number.parseInt(year) + Number(terms[key] !== "Fall");
-    (ret[`${yr} ${terms[key]}`] as QuarterDates).socAvailable = new Date(
+    (ret[`${yr} ${terms[key]}`] as ScrapedQuarterDates).socAvailable = new Date(
       yr - Number(terms[key] === "Winter"),
       months.indexOf(socAvailable[key].split(" ")[0]),
       Number.parseInt(socAvailable[key].split(" ")[1]),
@@ -203,8 +205,8 @@ export async function getTermDateData(year: string): Promise<Record<string, Quar
 
   for (const term of summerTerms) {
     const yr = Number.parseInt(year) + 1;
-    (ret[`${yr} ${term}`] as QuarterDates).socAvailable = new Date(`${yr}-03-01`);
+    (ret[`${yr} ${term}`] as ScrapedQuarterDates).socAvailable = new Date(`${yr}-03-01`);
   }
 
-  return ret as Record<string, QuarterDates>;
+  return ret as Record<string, ScrapedQuarterDates>;
 }

--- a/packages/types/types/calendar.ts
+++ b/packages/types/types/calendar.ts
@@ -20,4 +20,8 @@ export type QuarterDates = {
    * When finals end for the given quarter.
    */
   finalsEnd: Date;
+  /**
+   * When the Schedule of Classes becomes available for the given quarter.
+   */
+  socAvailable: Date;
 };

--- a/packages/types/types/calendar.ts
+++ b/packages/types/types/calendar.ts
@@ -1,3 +1,5 @@
+import type { Quarter } from "./constants";
+
 /**
  * An object that includes important dates for a specified quarter.
  * The type of the payload returned on a successful response from querying
@@ -5,23 +7,31 @@
  */
 export type QuarterDates = {
   /**
-   * When instruction begins for the given quarter.
+   * The year of the given term.
+   */
+  year: string;
+  /**
+   * The quarter of the given term.
+   */
+  quarter: Quarter;
+  /**
+   * When instruction begins for the given term.
    */
   instructionStart: Date;
   /**
-   * When instruction ends for the given quarter.
+   * When instruction ends for the given term.
    */
   instructionEnd: Date;
   /**
-   * When finals begin for the given quarter.
+   * When finals begin for the given term.
    */
   finalsStart: Date;
   /**
-   * When finals end for the given quarter.
+   * When finals end for the given term.
    */
   finalsEnd: Date;
   /**
-   * When the Schedule of Classes becomes available for the given quarter.
+   * When the Schedule of Classes becomes available for the given term.
    */
   socAvailable: Date;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,9 +305,9 @@ importers:
       '@libs/db':
         specifier: workspace:^
         version: link:../../libs/db
-      '@libs/uc-irvine-api':
+      '@libs/uc-irvine-lib':
         specifier: workspace:^
-        version: link:../../libs/uc-irvine-api
+        version: link:../../libs/uc-irvine-lib
       '@libs/utils':
         specifier: workspace:^
         version: link:../../libs/utils

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,25 @@ importers:
         specifier: 4.7.0
         version: 4.7.0
 
+  services/calendar-scraper:
+    dependencies:
+      '@libs/db':
+        specifier: workspace:^
+        version: link:../../libs/db
+      '@libs/uc-irvine-api':
+        specifier: workspace:^
+        version: link:../../libs/uc-irvine-api
+      '@libs/utils':
+        specifier: workspace:^
+        version: link:../../libs/utils
+    devDependencies:
+      '@peterportal-api/types':
+        specifier: workspace:^
+        version: link:../../packages/types
+      esbuild:
+        specifier: 0.20.0
+        version: 0.20.0
+
   services/websoc-proxy:
     dependencies:
       '@libs/lambda':

--- a/services/calendar-scraper/build.mjs
+++ b/services/calendar-scraper/build.mjs
@@ -1,0 +1,72 @@
+import { chmod, copyFile, mkdir, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { build } from "esbuild";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * @see https://github.com/evanw/esbuild/issues/1921#issuecomment-1623640043
+ */
+// language=JavaScript
+const js = `
+  import topLevelModule from "node:module";
+  import topLevelUrl from "node:url";
+  import topLevelPath from "node:path";
+
+  const require = topLevelModule.createRequire(import.meta.url);
+  const __filename = topLevelUrl.fileURLToPath(import.meta.url);
+  const __dirname = topLevelPath.dirname(__filename);
+`;
+
+async function buildApp() {
+  const options = {
+    entryPoints: { index: "index.ts" },
+    outdir: "dist",
+    outExtension: { ".js": ".mjs" },
+    bundle: true,
+    minify: true,
+    format: "esm",
+    platform: "node",
+    target: "node20",
+    logLevel: "info",
+    banner: { js },
+    plugins: [
+      {
+        name: "clean",
+        setup(build) {
+          build.onStart(async () => {
+            await rm(join(__dirname, "dist/"), { recursive: true, force: true });
+            await mkdir(join(__dirname, "dist/"));
+          });
+        },
+      },
+      {
+        name: "copy",
+        setup(build) {
+          build.onEnd(async () => {
+            await copyFile(
+              join(
+                __dirname,
+                "../../libs/db/node_modules/prisma/libquery_engine-linux-arm64-openssl-3.0.x.so.node",
+              ),
+              join(__dirname, "dist/libquery_engine-linux-arm64-openssl-3.0.x.so.node"),
+            );
+            await copyFile(
+              join(__dirname, "../../libs/db/prisma/schema.prisma"),
+              join(__dirname, "dist/schema.prisma"),
+            );
+            await chmod(
+              join(__dirname, "dist/libquery_engine-linux-arm64-openssl-3.0.x.so.node"),
+              0o755,
+            );
+          });
+        },
+      },
+    ],
+  };
+  await build(options);
+}
+
+buildApp().then();

--- a/services/calendar-scraper/package.json
+++ b/services/calendar-scraper/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@services/calendar-scraper",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "node build.mjs"
+  },
+  "dependencies": {
+    "@libs/db": "workspace:^",
+    "@libs/uc-irvine-api": "workspace:^",
+    "@libs/utils": "workspace:^"
+  },
+  "devDependencies": {
+    "@peterportal-api/types": "workspace:^",
+    "esbuild": "0.20.0"
+  }
+}

--- a/services/calendar-scraper/package.json
+++ b/services/calendar-scraper/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@libs/db": "workspace:^",
-    "@libs/uc-irvine-api": "workspace:^",
+    "@libs/uc-irvine-lib": "workspace:^",
     "@libs/utils": "workspace:^"
   },
   "devDependencies": {

--- a/services/calendar-scraper/package.json
+++ b/services/calendar-scraper/package.json
@@ -2,6 +2,7 @@
   "name": "@services/calendar-scraper",
   "version": "0.0.0",
   "private": true,
+  "description": "Automated scraper for key dates in a term",
   "license": "MIT",
   "type": "module",
   "main": "src/index.ts",

--- a/services/calendar-scraper/src/index.ts
+++ b/services/calendar-scraper/src/index.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@libs/db";
-import { getTermDateData } from "@libs/uc-irvine-api/registrar";
+import { getTermDateData } from "@libs/uc-irvine-lib/registrar";
 import type { Quarter } from "@peterportal-api/types";
 
 const prisma = new PrismaClient();

--- a/services/calendar-scraper/src/index.ts
+++ b/services/calendar-scraper/src/index.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from "@libs/db";
+import { getTermDateData } from "@libs/uc-irvine-api/registrar";
+import type { Quarter } from "@peterportal-api/types";
+
+const prisma = new PrismaClient();
+
+export const handler = async () => {
+  const lastYear = await prisma.calendarTerm.findMany({ select: { year: true } }).then(
+    (x) =>
+      Array.from(new Set(x.map((y) => y.year)))
+        .toSorted()
+        .findLast(() => true)!,
+  );
+  const termDateData = await getTermDateData(lastYear);
+  if (!Object.keys(termDateData).length) return;
+  await prisma.calendarTerm.createMany({
+    data: Object.entries(termDateData).map(([term, data]) => ({
+      year: term.split(" ")[0],
+      quarter: term.split(" ")[1] as Quarter,
+      ...data,
+    })),
+  });
+};

--- a/services/websoc-proxy/package.json
+++ b/services/websoc-proxy/package.json
@@ -2,6 +2,7 @@
   "name": "@services/websoc-proxy",
   "version": "0.0.0",
   "private": true,
+  "description": "Proxy microservice for WebSoc",
   "license": "MIT",
   "type": "module",
   "main": "src/index.ts",

--- a/services/websoc-scraper-v2/package.json
+++ b/services/websoc-scraper-v2/package.json
@@ -2,6 +2,7 @@
   "name": "@services/websoc-scraper-v2",
   "version": "0.0.0",
   "private": true,
+  "description": "Automated scraper for WebSoc data",
   "license": "MIT",
   "main": "index.ts",
   "scripts": {

--- a/tools/cdk/src/constructs/CalendarScraper.ts
+++ b/tools/cdk/src/constructs/CalendarScraper.ts
@@ -1,0 +1,45 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Duration } from "aws-cdk-lib";
+import { Rule, RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
+import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
+import { Architecture, Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
+export class CalendarScraper extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const ruleName = `${id}-rule`;
+
+    const rule = new Rule(this, ruleName, {
+      ruleName,
+      schedule: Schedule.rate(Duration.days(90)),
+    });
+
+    const functionName = `${id}-function`;
+
+    rule.addTarget(
+      new LambdaFunction(
+        new Function(this, functionName, {
+          architecture: Architecture.ARM_64,
+          code: Code.fromAsset(
+            join(
+              dirname(fileURLToPath(import.meta.url)),
+              "../../../../services/calendar-scraper/dist",
+            ),
+          ),
+          functionName,
+          handler: "index.handler",
+          timeout: Duration.seconds(15),
+          runtime: Runtime.NODEJS_20_X,
+          memorySize: 512,
+        }),
+        {
+          event: RuleTargetInput.fromObject({ body: "{}" }),
+        },
+      ),
+    );
+  }
+}

--- a/tools/cdk/src/stacks/services.ts
+++ b/tools/cdk/src/stacks/services.ts
@@ -3,6 +3,7 @@ import type { StackProps } from "aws-cdk-lib";
 import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
 import type { Construct } from "constructs";
 
+import { CalendarScraper } from "../constructs/CalendarScraper";
 import { WebsocProxy } from "../constructs/WebsocProxy";
 import { WebsocScraperV2 } from "../constructs/WebsocScraperV2";
 
@@ -26,6 +27,8 @@ export class ServicesStack extends Stack {
         },
       ],
     });
+
+    new CalendarScraper(this, `${id}-calendar-scraper`);
 
     new WebsocProxy(this, `${id}-websoc-proxy`);
 


### PR DESCRIPTION
## Summary
- Add automated scraper for the calendar endpoint, which will run every three months (probably on the generous side but you never know).
- Calling `/v1/rest/calendar` with no params will now dump all terms in the database. The GraphQL query `allTermDates` accomplishes the same.
- Add the field `socAvailable` to the response type, which indicates when the Schedule of Classes will become available for that term.

## Issues
Closes #111; closes #124.