### PR TITLE
feat: fuzzy SaaS proof of concept (WIP)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,7 @@
     "@graphql-tools/load-files": "7.0.0",
     "@graphql-tools/merge": "9.0.3",
     "@graphql-tools/utils": "10.1.0",
+    "@leeoniya/ufuzzy": "1.0.14",
     "@libs/db": "workspace:^",
     "@libs/lambda": "workspace:^",
     "@libs/uc-irvine-lib": "workspace:^",

--- a/apps/api/src/global.d.ts
+++ b/apps/api/src/global.d.ts
@@ -19,3 +19,10 @@ declare module "virtual:instructors" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   declare const instructors: Record<string, import("@peterportal-api/types").Instructor>;
 }
+/**
+ * Virtual module for caching the haystack and mappings for fuzzy search during build time.
+ */
+declare module "virtual:search" {
+  declare const haystack: string[];
+  declare const mapping: string[];
+}

--- a/apps/api/src/routes/v1/graphql/resolvers.ts
+++ b/apps/api/src/routes/v1/graphql/resolvers.ts
@@ -23,6 +23,12 @@ export const resolvers: ApolloServerOptions<BaseContext>["resolvers"] = {
     instructors: proxyRestApi("/v1/rest/instructors"),
     allInstructors: proxyRestApi("/v1/rest/instructors/all"),
     larc: proxyRestApi("/v1/rest/larc"),
+    searchCourses: proxyRestApi("/v1/rest/search", {
+      argsTransform: (args) => ({ ...args, resultType: "course" }),
+    }),
+    searchInstructors: proxyRestApi("/v1/rest/search", {
+      argsTransform: (args) => ({ ...args, resultType: "instructors" }),
+    }),
     websoc: proxyRestApi("/v1/rest/websoc", { argsTransform: geTransform }),
     depts: proxyRestApi("/v1/rest/websoc/depts"),
     terms: proxyRestApi("/v1/rest/websoc/terms"),

--- a/apps/api/src/routes/v1/graphql/schema/search.graphql
+++ b/apps/api/src/routes/v1/graphql/schema/search.graphql
@@ -1,0 +1,14 @@
+type CourseSearchResult {
+  count: Int!
+  results: [Course!]!
+}
+
+type InstructorSearchResult {
+  count: Int!
+  results: [Instructor!]!
+}
+
+extend type Query {
+  searchCourses(query: String!, limit: Int, offset: Int): CourseSearchResult!
+  searchInstructors(query: String!, limit: Int, offset: Int): InstructorSearchResult!
+}

--- a/apps/api/src/routes/v1/rest/search/+config.ts
+++ b/apps/api/src/routes/v1/rest/search/+config.ts
@@ -1,0 +1,11 @@
+import type { ApiPropsOverride } from "@bronya.js/api-construct";
+
+import { esbuildOptions, constructs } from "../../../../../bronya.config";
+
+export const overrides: ApiPropsOverride = {
+  esbuild: esbuildOptions,
+  constructs: {
+    functionPlugin: constructs.functionPlugin,
+    restApiProps: constructs.restApiProps,
+  },
+};

--- a/apps/api/src/routes/v1/rest/search/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/search/+endpoint.ts
@@ -1,0 +1,36 @@
+import uFuzzy from "@leeoniya/ufuzzy";
+import { createHandler } from "@libs/lambda";
+import type { Course, Instructor } from "@peterportal-api/types";
+import { courses } from "virtual:courses";
+import { instructors } from "virtual:instructors";
+import { haystack, mapping } from "virtual:search";
+
+import { QuerySchema } from "./schema";
+
+const u = new uFuzzy({ intraMode: 1 /* IntraMode.SingleError */ });
+
+export const GET = createHandler(async (event, context, res) => {
+  const headers = event.headers;
+  const requestId = context.awsRequestId;
+  const query = event.queryStringParameters ?? {};
+
+  const maybeParsed = QuerySchema.safeParse(query);
+  if (maybeParsed.success) {
+    const { data } = maybeParsed;
+    const keys = Array.from(new Set(u.search(haystack, data.q)[0]?.map((x) => mapping[x])));
+    const results: Array<Course | Instructor> = keys
+      .slice(data.offset, data.offset + data.limit)
+      .map((x) => courses[x] ?? instructors[x]);
+    return res.createOKResult(
+      {
+        count: keys.length,
+        results: results.filter((x) =>
+          !data.resultType ? x : data.resultType === "course" ? "id" in x : "ucinetid" in x,
+        ),
+      },
+      headers,
+      requestId,
+    );
+  }
+  return res.createErrorResult(400, "Search query not provided", requestId);
+});

--- a/apps/api/src/routes/v1/rest/search/+endpoint.ts
+++ b/apps/api/src/routes/v1/rest/search/+endpoint.ts
@@ -17,7 +17,7 @@ export const GET = createHandler(async (event, context, res) => {
   const maybeParsed = QuerySchema.safeParse(query);
   if (maybeParsed.success) {
     const { data } = maybeParsed;
-    const keys = Array.from(new Set(u.search(haystack, data.q)[0]?.map((x) => mapping[x])));
+    const keys = Array.from(new Set(u.search(haystack, data.query)[0]?.map((x) => mapping[x])));
     const results: Array<Course | Instructor> = keys
       .map((x) => courses[x] ?? instructors[x])
       .filter((x) =>

--- a/apps/api/src/routes/v1/rest/search/schema.ts
+++ b/apps/api/src/routes/v1/rest/search/schema.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
 export const QuerySchema = z.object({
-  q: z.string(),
+  query: z.string(),
   resultType: z.enum(["course", "instructor"]).optional(),
-  limit: z.coerce.number().default(10),
-  offset: z.coerce.number().default(0),
+  limit: z.coerce.number().int().default(10),
+  offset: z.coerce.number().int().default(0),
 });
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/apps/api/src/routes/v1/rest/search/schema.ts
+++ b/apps/api/src/routes/v1/rest/search/schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const QuerySchema = z.object({
+  q: z.string(),
+  resultType: z.enum(["course", "instructor"]).optional(),
+  limit: z.coerce.number().default(10),
+  offset: z.coerce.number().default(0),
+});
+
+export type Query = z.infer<typeof QuerySchema>;

--- a/libs/db/prisma/schema.prisma
+++ b/libs/db/prisma/schema.prisma
@@ -46,6 +46,11 @@ enum WebsocSectionType {
 
 // Models
 
+model Alias {
+  department String @id
+  alias      String
+}
+
 model CalendarTerm {
   year             String
   quarter          Quarter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@graphql-tools/utils':
         specifier: 10.1.0
         version: 10.1.0(graphql@16.8.1)
+      '@leeoniya/ufuzzy':
+        specifier: 1.0.14
+        version: 1.0.14
       '@libs/db':
         specifier: workspace:^
         version: link:../../libs/db
@@ -2876,16 +2879,6 @@ packages:
       conventional-changelog-conventionalcommits: 7.0.2
     dev: false
 
-  /@commitlint/config-validator@18.6.0:
-    resolution: {integrity: sha512-Ptfa865arNozlkjxrYG3qt6wT9AlhNUHeuDyKEZiTL/l0ftncFhK/KN0t/EAMV2tec+0Mwxo0FmhbESj/bI+1g==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/types': 18.6.0
-      ajv: 8.12.0
-    dev: false
-    optional: true
-
   /@commitlint/config-validator@19.0.3:
     resolution: {integrity: sha512-2D3r4PKjoo59zBc2auodrSCaUnCSALCx54yveOFwwP/i2kfEAQrygwOleFWswLqK0UL/F9r07MFi5ev2ohyM4Q==}
     engines: {node: '>=v18'}
@@ -2905,13 +2898,6 @@ packages:
       lodash.startcase: 4.4.0
       lodash.upperfirst: 4.3.1
     dev: false
-
-  /@commitlint/execute-rule@18.4.4:
-    resolution: {integrity: sha512-a37Nd3bDQydtg9PCLLWM9ZC+GO7X5i4zJvrggJv5jBhaHsXeQ9ZWdO6ODYR+f0LxBXXNYK3geYXJrCWUCP8JEg==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@commitlint/execute-rule@19.0.0:
     resolution: {integrity: sha512-mtsdpY1qyWgAO/iOK0L6gSGeR7GFcdW7tIjcNFxcWkfLDF5qVbPHKuGATFqRMsxcO8OUKNj0+3WOHB7EHm4Jdw==}
@@ -2943,28 +2929,6 @@ packages:
       '@commitlint/rules': 19.0.3
       '@commitlint/types': 19.0.3
     dev: false
-
-  /@commitlint/load@18.6.0(@types/node@20.11.24)(typescript@5.3.3):
-    resolution: {integrity: sha512-RRssj7TmzT0bowoEKlgwg8uQ7ORXWkw7lYLsZZBMi9aInsJuGNLNWcMxJxRZbwxG3jkCidGUg85WmqJvRjsaDA==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/config-validator': 18.6.0
-      '@commitlint/execute-rule': 18.4.4
-      '@commitlint/resolve-extends': 18.6.0
-      '@commitlint/types': 18.6.0
-      chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.3.3)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@20.11.24)(cosmiconfig@8.3.6)(typescript@5.3.3)
-      lodash.isplainobject: 4.0.6
-      lodash.merge: 4.6.2
-      lodash.uniq: 4.5.0
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - typescript
-    dev: false
-    optional: true
 
   /@commitlint/load@19.0.3(@types/node@20.11.24)(typescript@5.3.3):
     resolution: {integrity: sha512-18Tk/ZcDFRKIoKfEcl7kC+bYkEQ055iyKmGsYDoYWpKf6FUvBrP9bIWapuy/MB+kYiltmP9ITiUx6UXtqC9IRw==}
@@ -3009,20 +2973,6 @@ packages:
       minimist: 1.2.8
     dev: false
 
-  /@commitlint/resolve-extends@18.6.0:
-    resolution: {integrity: sha512-k2Xp+Fxeggki2i90vGrbiLDMefPius3zGSTFFlRAPKce/SWLbZtI+uqE9Mne23mHO5lmcSV8z5m6ziiJwGpOcg==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/config-validator': 18.6.0
-      '@commitlint/types': 18.6.0
-      import-fresh: 3.3.0
-      lodash.mergewith: 4.6.2
-      resolve-from: 5.0.0
-      resolve-global: 1.0.0
-    dev: false
-    optional: true
-
   /@commitlint/resolve-extends@19.0.3:
     resolution: {integrity: sha512-18BKmta8OC8+Ub+Q3QGM9l27VjQaXobloVXOrMvu8CpEwJYv62vC/t7Ka5kJnsW0tU9q1eMqJFZ/nN9T/cOaIA==}
     engines: {node: '>=v18'}
@@ -3057,15 +3007,6 @@ packages:
     dependencies:
       find-up: 7.0.0
     dev: false
-
-  /@commitlint/types@18.6.0:
-    resolution: {integrity: sha512-oavoKLML/eJa2rJeyYSbyGAYzTxQ6voG5oeX3OrxpfrkRWhJfm4ACnhoRf5tgiybx2MZ+EVFqC1Lw3W8/uwpZA==}
-    engines: {node: '>=v18'}
-    requiresBuild: true
-    dependencies:
-      chalk: 4.1.2
-    dev: false
-    optional: true
 
   /@commitlint/types@19.0.3:
     resolution: {integrity: sha512-tpyc+7i6bPG9mvaBbtKUeghfyZSDgWquIDfMgqYtTbmZ9Y9VzEm2je9EYcQ0aoz5o7NvGS+rcDec93yO08MHYA==}
@@ -4485,6 +4426,10 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+
+  /@leeoniya/ufuzzy@1.0.14:
+    resolution: {integrity: sha512-/xF4baYuCQMo+L/fMSUrZnibcu0BquEGnbxfVPiZhs/NbJeKj4c/UmFpQzW9Us0w45ui/yYW3vyaqawhNYsTzA==}
+    dev: false
 
   /@leichtgewicht/ip-codec@2.0.4:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
@@ -7373,7 +7318,7 @@ packages:
       longest: 2.0.1
       word-wrap: 1.2.3
     optionalDependencies:
-      '@commitlint/load': 18.6.0(@types/node@20.11.24)(typescript@5.3.3)
+      '@commitlint/load': 19.0.3(@types/node@20.11.24)(typescript@5.3.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -8780,15 +8725,6 @@ packages:
     dependencies:
       ini: 4.1.1
     dev: false
-
-  /global-dirs@0.1.1:
-    resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
-    engines: {node: '>=4'}
-    requiresBuild: true
-    dependencies:
-      ini: 1.3.8
-    dev: false
-    optional: true
 
   /global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -11910,15 +11846,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-
-  /resolve-global@1.0.0:
-    resolution: {integrity: sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==}
-    engines: {node: '>=8'}
-    requiresBuild: true
-    dependencies:
-      global-dirs: 0.1.1
-    dev: false
-    optional: true
 
   /resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}


### PR DESCRIPTION
## Summary

Implement fuzzy search as a service through REST and GraphQL (`searchCourses` and `searchInstructors`, since GraphQL doesn't support tagged union/sum types).

The total number of results is returned in the `count` field in the payload, and the result set (containing at most the requested number of results starting from the offset) is returned in the `results` field.

### Parameters
- `query`: The string to fuzzy-search. Required.
- `resultType`: The type of result to return exclusively, `course` or `instructor`. Both types of results will be returned if left undefined.
- `limit` and `offset`: For pagination purposes, defaults to 10 and 0 respectively.

## Issues

Closes #131.